### PR TITLE
fix variant encode bug

### DIFF
--- a/lib/conv/msgpack_conv.ml
+++ b/lib/conv/msgpack_conv.ml
@@ -11,7 +11,7 @@ include Meta_conv.Coder.Make(struct
     let tuple =
       Encode.array
 
-    let variant tag _ = function
+    let variant _ tag = function
       | [] -> Encode.str tag
       | ts -> Encode.map [Encode.str tag, Encode.array ts]
 

--- a/test/conv/convTest.ml
+++ b/test/conv/convTest.ml
@@ -71,6 +71,9 @@ let tests = [
   "varint" >:: begin fun () ->
     check
       msgpack_of_t6 t6_of_msgpack_exn
-        (`FixMap [`FixRaw ['F'; 'o'; 'o' ], `FixArray [`PFixnum 42]]) (Foo 42)
+        (`FixMap [`FixRaw ['F'; 'o'; 'o' ], `FixArray [`PFixnum 42]]) (Foo 42);
+    check
+      msgpack_of_t6 t6_of_msgpack_exn
+        (`FixRaw ['B'; 'a'; 'r' ]) Bar
   end
 ]


### PR DESCRIPTION
fix failed test

before
```
$ make test
ocaml setup.ml -build 
Finished, 0 targets (0 cached) in 00:00:00.
Configuration "true: quiet, debug, tests", line 1, characters 20-25:
Warning: the tag "tests" is not used in any flag declaration, so it will have no effect; it may be a typo. Otherwise use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
Finished, 67 targets (54 cached) in 00:00:01.
ocaml setup.ml -test 
......................................................................................................................................
Ran: 134 tests in: 0.20 seconds.
OK
.....F
==============================================================================
Failure: conv:0:conv.ml:5:varint

not equal
------------------------------------------------------------------------------
Ran: 6 tests in: 0.00 seconds.
FAILED: Cases: 6 Tried: 6 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
```

after
```
$ make test
ocaml setup.ml -build 
Finished, 0 targets (0 cached) in 00:00:00.
Configuration "true: quiet, debug, tests", line 1, characters 20-25:
Warning: the tag "tests" is not used in any flag declaration, so it will have no effect; it may be a typo. Otherwise use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
Finished, 67 targets (54 cached) in 00:00:01.
ocaml setup.ml -test 
......................................................................................................................................
Ran: 134 tests in: 0.19 seconds.
OK
......
Ran: 6 tests in: 0.00 seconds.
OK
```