### PR TITLE
Fix stack-overflow crashes by using tail-recursive list functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,6 @@ You need Coq 8.4 and omake.
 ``` bash
 $ cd proof
 $ make
-$ cp *.ml ../lib
+$ cp *.ml* ../lib/core
 ```
 

--- a/_oasis
+++ b/_oasis
@@ -41,8 +41,8 @@ Library msgpack
   InternalModules: HList, MsgpackCore, Pack, Serialize, MsgpackConfig, Base
   CompiledObject: best
   # supress warning for Coq-extracted code
-  ByteOpt: -w +a-27-39-4 -annot
-  NativeOpt: -w +a-27-39-4 -annot
+  ByteOpt: -g -w +a-27-39-4 -annot
+  NativeOpt: -g -w +a-27-39-4 -annot
   BuildDepends: num
 
 Library msgpack_conv
@@ -52,8 +52,8 @@ Library msgpack_conv
   Modules: Msgpack_conv
   InternalModules: Encode, Decode
   CompiledObject: best
-  ByteOpt: -w +a -annot
-  NativeOpt: -w +a -annot
+  ByteOpt: -g -w +a -annot
+  NativeOpt: -g -w +a -annot
 
   # install as msgpack.conv
   FindlibName: conv

--- a/lib/core/msgpackCore.ml
+++ b/lib/core/msgpackCore.ml
@@ -19,16 +19,11 @@ let snd = function
 
 (** val length : 'a1 list -> int **)
 
-let rec length = function
-| [] -> 0
-| y::l' -> Pervasives.succ (length l')
+let rec length = List.length
 
 (** val app : 'a1 list -> 'a1 list -> 'a1 list **)
 
-let rec app l m =
-  match l with
-  | [] -> m
-  | a::l1 -> a::(app l1 m)
+let rec app = (fun l m -> List.rev (List.rev_append m (List.rev l)))
 
 type comparison =
 | Eq
@@ -2059,9 +2054,7 @@ module N =
 
 (** val flat_map : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list **)
 
-let rec flat_map f = function
-| [] -> []
-| x::t0 -> app (f x) (flat_map f t0)
+let rec flat_map = (fun f xs -> List.rev (List.fold_left (fun acc x -> List.rev_append (f x) acc) [] xs))
 
 (** val eucl_dev : int -> int -> (int * int) **)
 

--- a/lib/core/msgpackCore.ml
+++ b/lib/core/msgpackCore.ml
@@ -1,27 +1,62 @@
+type __ = Obj.t
 let __ = let rec f _ = Obj.repr f in Obj.repr f
+
+(** val negb : bool -> bool **)
+
+let negb = function
+| true -> false
+| false -> true
 
 (** val fst : ('a1 * 'a2) -> 'a1 **)
 
 let fst = function
-  | (x, y) -> x
+| (x, y) -> x
 
 (** val snd : ('a1 * 'a2) -> 'a2 **)
 
 let snd = function
-  | (x, y) -> y
+| (x, y) -> y
 
 (** val length : 'a1 list -> int **)
 
 let rec length = function
-  | [] -> 0
-  | y::l' -> succ (length l')
+| [] -> 0
+| y::l' -> Pervasives.succ (length l')
 
 (** val app : 'a1 list -> 'a1 list -> 'a1 list **)
 
 let rec app l m =
   match l with
-    | [] -> m
-    | a::l1 -> a::(app l1 m)
+  | [] -> m
+  | a::l1 -> a::(app l1 m)
+
+type comparison =
+| Eq
+| Lt
+| Gt
+
+type compareSpecT =
+| CompEqT
+| CompLtT
+| CompGtT
+
+(** val compareSpec2Type : comparison -> compareSpecT **)
+
+let compareSpec2Type = function
+| Eq -> CompEqT
+| Lt -> CompLtT
+| Gt -> CompGtT
+
+type 'a compSpecT = compareSpecT
+
+(** val compSpec2Type : 'a1 -> 'a1 -> comparison -> 'a1 compSpecT **)
+
+let compSpec2Type x y c =
+  compareSpec2Type c
+
+type 'a sig0 =
+  'a
+  (* singleton inductive, whose constructor was exist *)
 
 (** val plus : int -> int -> int **)
 
@@ -31,214 +66,2094 @@ let rec plus = (+)
 
 let rec mult = ( * )
 
-type positive =
-  | XI of positive
-  | XO of positive
-  | XH
+(** val nat_iter : int -> ('a1 -> 'a1) -> 'a1 -> 'a1 **)
 
-(** val psucc : positive -> positive **)
-
-let rec psucc = function
-  | XI p -> XO (psucc p)
-  | XO p -> XI p
-  | XH -> XO XH
-
-(** val pplus : positive -> positive -> positive **)
-
-let rec pplus x y =
-  match x with
-    | XI p ->
-        (match y with
-           | XI q -> XO (pplus_carry p q)
-           | XO q -> XI (pplus p q)
-           | XH -> XO (psucc p))
-    | XO p ->
-        (match y with
-           | XI q -> XI (pplus p q)
-           | XO q -> XO (pplus p q)
-           | XH -> XI p)
-    | XH ->
-        (match y with
-           | XI q -> XO (psucc q)
-           | XO q -> XI q
-           | XH -> XO XH)
-
-(** val pplus_carry : positive -> positive -> positive **)
-
-and pplus_carry x y =
-  match x with
-    | XI p ->
-        (match y with
-           | XI q -> XI (pplus_carry p q)
-           | XO q -> XO (pplus_carry p q)
-           | XH -> XI (psucc p))
-    | XO p ->
-        (match y with
-           | XI q -> XO (pplus_carry p q)
-           | XO q -> XI (pplus p q)
-           | XH -> XO (psucc p))
-    | XH ->
-        (match y with
-           | XI q -> XI (psucc q)
-           | XO q -> XO (psucc q)
-           | XH -> XI XH)
-
-(** val pmult_nat : positive -> int -> int **)
-
-let rec pmult_nat x pow2 =
-  match x with
-    | XI p -> plus pow2 (pmult_nat p (plus pow2 pow2))
-    | XO p -> pmult_nat p (plus pow2 pow2)
-    | XH -> pow2
-
-(** val nat_of_P : positive -> int **)
-
-let nat_of_P x =
-  pmult_nat x (succ 0)
-
-(** val p_of_succ_nat : int -> positive **)
-
-let rec p_of_succ_nat n0 =
+let rec nat_iter n0 f x =
   (fun fO fS n -> if n=0 then fO () else fS (n-1))
-    (fun _ -> XH)
-    (fun x -> psucc (p_of_succ_nat x))
+    (fun _ ->
+    x)
+    (fun n' ->
+    f (nat_iter n' f x))
     n0
 
-(** val pmult : positive -> positive -> positive **)
-
-let rec pmult x y =
-  match x with
-    | XI p -> pplus y (XO (pmult p y))
-    | XO p -> XO (pmult p y)
-    | XH -> y
+type positive =
+| XI of positive
+| XO of positive
+| XH
 
 type n =
-  | N0
-  | Npos of positive
+| N0
+| Npos of positive
 
-(** val nplus : n -> n -> n **)
+type reflect =
+| ReflectT
+| ReflectF
 
-let nplus n0 m =
-  match n0 with
+(** val iff_reflect : bool -> reflect **)
+
+let iff_reflect = function
+| true -> ReflectT
+| false -> ReflectF
+
+module Pos = 
+ struct 
+  type t = positive
+  
+  (** val succ : positive -> positive **)
+  
+  let rec succ = function
+  | XI p -> XO (succ p)
+  | XO p -> XI p
+  | XH -> XO XH
+  
+  (** val add : positive -> positive -> positive **)
+  
+  let rec add x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> XO (add_carry p q)
+       | XO q -> XI (add p q)
+       | XH -> XO (succ p))
+    | XO p ->
+      (match y with
+       | XI q -> XI (add p q)
+       | XO q -> XO (add p q)
+       | XH -> XI p)
+    | XH ->
+      (match y with
+       | XI q -> XO (succ q)
+       | XO q -> XI q
+       | XH -> XO XH)
+  
+  (** val add_carry : positive -> positive -> positive **)
+  
+  and add_carry x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> XI (add_carry p q)
+       | XO q -> XO (add_carry p q)
+       | XH -> XI (succ p))
+    | XO p ->
+      (match y with
+       | XI q -> XO (add_carry p q)
+       | XO q -> XI (add p q)
+       | XH -> XO (succ p))
+    | XH ->
+      (match y with
+       | XI q -> XI (succ q)
+       | XO q -> XO (succ q)
+       | XH -> XI XH)
+  
+  (** val pred_double : positive -> positive **)
+  
+  let rec pred_double = function
+  | XI p -> XI (XO p)
+  | XO p -> XI (pred_double p)
+  | XH -> XH
+  
+  (** val pred : positive -> positive **)
+  
+  let pred = function
+  | XI p -> XO p
+  | XO p -> pred_double p
+  | XH -> XH
+  
+  (** val pred_N : positive -> n **)
+  
+  let pred_N = function
+  | XI p -> Npos (XO p)
+  | XO p -> Npos (pred_double p)
+  | XH -> N0
+  
+  type mask =
+  | IsNul
+  | IsPos of positive
+  | IsNeg
+  
+  (** val mask_rect : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1 **)
+  
+  let mask_rect f f0 f1 = function
+  | IsNul -> f
+  | IsPos x -> f0 x
+  | IsNeg -> f1
+  
+  (** val mask_rec : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1 **)
+  
+  let mask_rec f f0 f1 = function
+  | IsNul -> f
+  | IsPos x -> f0 x
+  | IsNeg -> f1
+  
+  (** val succ_double_mask : mask -> mask **)
+  
+  let succ_double_mask = function
+  | IsNul -> IsPos XH
+  | IsPos p -> IsPos (XI p)
+  | IsNeg -> IsNeg
+  
+  (** val double_mask : mask -> mask **)
+  
+  let double_mask = function
+  | IsPos p -> IsPos (XO p)
+  | x0 -> x0
+  
+  (** val double_pred_mask : positive -> mask **)
+  
+  let double_pred_mask = function
+  | XI p -> IsPos (XO (XO p))
+  | XO p -> IsPos (XO (pred_double p))
+  | XH -> IsNul
+  
+  (** val pred_mask : mask -> mask **)
+  
+  let pred_mask = function
+  | IsPos q ->
+    (match q with
+     | XH -> IsNul
+     | _ -> IsPos (pred q))
+  | _ -> IsNeg
+  
+  (** val sub_mask : positive -> positive -> mask **)
+  
+  let rec sub_mask x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> double_mask (sub_mask p q)
+       | XO q -> succ_double_mask (sub_mask p q)
+       | XH -> IsPos (XO p))
+    | XO p ->
+      (match y with
+       | XI q -> succ_double_mask (sub_mask_carry p q)
+       | XO q -> double_mask (sub_mask p q)
+       | XH -> IsPos (pred_double p))
+    | XH ->
+      (match y with
+       | XH -> IsNul
+       | _ -> IsNeg)
+  
+  (** val sub_mask_carry : positive -> positive -> mask **)
+  
+  and sub_mask_carry x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> succ_double_mask (sub_mask_carry p q)
+       | XO q -> double_mask (sub_mask p q)
+       | XH -> IsPos (pred_double p))
+    | XO p ->
+      (match y with
+       | XI q -> double_mask (sub_mask_carry p q)
+       | XO q -> succ_double_mask (sub_mask_carry p q)
+       | XH -> double_pred_mask p)
+    | XH -> IsNeg
+  
+  (** val sub : positive -> positive -> positive **)
+  
+  let sub x y =
+    match sub_mask x y with
+    | IsPos z -> z
+    | _ -> XH
+  
+  (** val mul : positive -> positive -> positive **)
+  
+  let rec mul x y =
+    match x with
+    | XI p -> add y (XO (mul p y))
+    | XO p -> XO (mul p y)
+    | XH -> y
+  
+  (** val iter : positive -> ('a1 -> 'a1) -> 'a1 -> 'a1 **)
+  
+  let rec iter n0 f x =
+    match n0 with
+    | XI n' -> f (iter n' f (iter n' f x))
+    | XO n' -> iter n' f (iter n' f x)
+    | XH -> f x
+  
+  (** val pow : positive -> positive -> positive **)
+  
+  let pow x y =
+    iter y (mul x) XH
+  
+  (** val square : positive -> positive **)
+  
+  let rec square = function
+  | XI p0 -> XI (XO (add (square p0) p0))
+  | XO p0 -> XO (XO (square p0))
+  | XH -> XH
+  
+  (** val div2 : positive -> positive **)
+  
+  let div2 = function
+  | XI p0 -> p0
+  | XO p0 -> p0
+  | XH -> XH
+  
+  (** val div2_up : positive -> positive **)
+  
+  let div2_up = function
+  | XI p0 -> succ p0
+  | XO p0 -> p0
+  | XH -> XH
+  
+  (** val size_nat : positive -> int **)
+  
+  let rec size_nat = function
+  | XI p0 -> Pervasives.succ (size_nat p0)
+  | XO p0 -> Pervasives.succ (size_nat p0)
+  | XH -> Pervasives.succ 0
+  
+  (** val size : positive -> positive **)
+  
+  let rec size = function
+  | XI p0 -> succ (size p0)
+  | XO p0 -> succ (size p0)
+  | XH -> XH
+  
+  (** val compare_cont : positive -> positive -> comparison -> comparison **)
+  
+  let rec compare_cont x y r =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> compare_cont p q r
+       | XO q -> compare_cont p q Gt
+       | XH -> Gt)
+    | XO p ->
+      (match y with
+       | XI q -> compare_cont p q Lt
+       | XO q -> compare_cont p q r
+       | XH -> Gt)
+    | XH ->
+      (match y with
+       | XH -> r
+       | _ -> Lt)
+  
+  (** val compare : positive -> positive -> comparison **)
+  
+  let compare x y =
+    compare_cont x y Eq
+  
+  (** val min : positive -> positive -> positive **)
+  
+  let min p p' =
+    match compare p p' with
+    | Gt -> p'
+    | _ -> p
+  
+  (** val max : positive -> positive -> positive **)
+  
+  let max p p' =
+    match compare p p' with
+    | Gt -> p
+    | _ -> p'
+  
+  (** val eqb : positive -> positive -> bool **)
+  
+  let rec eqb p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> eqb p0 q0
+       | _ -> false)
+    | XO p0 ->
+      (match q with
+       | XO q0 -> eqb p0 q0
+       | _ -> false)
+    | XH ->
+      (match q with
+       | XH -> true
+       | _ -> false)
+  
+  (** val leb : positive -> positive -> bool **)
+  
+  let leb x y =
+    match compare x y with
+    | Gt -> false
+    | _ -> true
+  
+  (** val ltb : positive -> positive -> bool **)
+  
+  let ltb x y =
+    match compare x y with
+    | Lt -> true
+    | _ -> false
+  
+  (** val sqrtrem_step :
+      (positive -> positive) -> (positive -> positive) -> (positive * mask)
+      -> positive * mask **)
+  
+  let sqrtrem_step f g = function
+  | (s, y) ->
+    (match y with
+     | IsPos r ->
+       let s' = XI (XO s) in
+       let r' = g (f r) in
+       if leb s' r' then ((XI s), (sub_mask r' s')) else ((XO s), (IsPos r'))
+     | _ -> ((XO s), (sub_mask (g (f XH)) (XO (XO XH)))))
+  
+  (** val sqrtrem : positive -> positive * mask **)
+  
+  let rec sqrtrem = function
+  | XI p0 ->
+    (match p0 with
+     | XI p1 -> sqrtrem_step (fun x -> XI x) (fun x -> XI x) (sqrtrem p1)
+     | XO p1 -> sqrtrem_step (fun x -> XO x) (fun x -> XI x) (sqrtrem p1)
+     | XH -> (XH, (IsPos (XO XH))))
+  | XO p0 ->
+    (match p0 with
+     | XI p1 -> sqrtrem_step (fun x -> XI x) (fun x -> XO x) (sqrtrem p1)
+     | XO p1 -> sqrtrem_step (fun x -> XO x) (fun x -> XO x) (sqrtrem p1)
+     | XH -> (XH, (IsPos XH)))
+  | XH -> (XH, IsNul)
+  
+  (** val sqrt : positive -> positive **)
+  
+  let sqrt p =
+    fst (sqrtrem p)
+  
+  (** val gcdn : int -> positive -> positive -> positive **)
+  
+  let rec gcdn n0 a b =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun n1 ->
+      match a with
+      | XI a' ->
+        (match b with
+         | XI b' ->
+           (match compare a' b' with
+            | Eq -> a
+            | Lt -> gcdn n1 (sub b' a') a
+            | Gt -> gcdn n1 (sub a' b') b)
+         | XO b0 -> gcdn n1 a b0
+         | XH -> XH)
+      | XO a0 ->
+        (match b with
+         | XI p -> gcdn n1 a0 b
+         | XO b0 -> XO (gcdn n1 a0 b0)
+         | XH -> XH)
+      | XH -> XH)
+      n0
+  
+  (** val gcd : positive -> positive -> positive **)
+  
+  let gcd a b =
+    gcdn (plus (size_nat a) (size_nat b)) a b
+  
+  (** val ggcdn :
+      int -> positive -> positive -> positive * (positive * positive) **)
+  
+  let rec ggcdn n0 a b =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ -> (XH, (a,
+      b)))
+      (fun n1 ->
+      match a with
+      | XI a' ->
+        (match b with
+         | XI b' ->
+           (match compare a' b' with
+            | Eq -> (a, (XH, XH))
+            | Lt ->
+              let (g, p) = ggcdn n1 (sub b' a') a in
+              let (ba, aa) = p in (g, (aa, (add aa (XO ba))))
+            | Gt ->
+              let (g, p) = ggcdn n1 (sub a' b') b in
+              let (ab, bb) = p in (g, ((add bb (XO ab)), bb)))
+         | XO b0 ->
+           let (g, p) = ggcdn n1 a b0 in
+           let (aa, bb) = p in (g, (aa, (XO bb)))
+         | XH -> (XH, (a, XH)))
+      | XO a0 ->
+        (match b with
+         | XI p ->
+           let (g, p0) = ggcdn n1 a0 b in
+           let (aa, bb) = p0 in (g, ((XO aa), bb))
+         | XO b0 -> let (g, p) = ggcdn n1 a0 b0 in ((XO g), p)
+         | XH -> (XH, (a, XH)))
+      | XH -> (XH, (XH, b)))
+      n0
+  
+  (** val ggcd : positive -> positive -> positive * (positive * positive) **)
+  
+  let ggcd a b =
+    ggcdn (plus (size_nat a) (size_nat b)) a b
+  
+  (** val coq_Nsucc_double : n -> n **)
+  
+  let coq_Nsucc_double = function
+  | N0 -> Npos XH
+  | Npos p -> Npos (XI p)
+  
+  (** val coq_Ndouble : n -> n **)
+  
+  let coq_Ndouble = function
+  | N0 -> N0
+  | Npos p -> Npos (XO p)
+  
+  (** val coq_lor : positive -> positive -> positive **)
+  
+  let rec coq_lor p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> XI (coq_lor p0 q0)
+       | XO q0 -> XI (coq_lor p0 q0)
+       | XH -> p)
+    | XO p0 ->
+      (match q with
+       | XI q0 -> XI (coq_lor p0 q0)
+       | XO q0 -> XO (coq_lor p0 q0)
+       | XH -> XI p0)
+    | XH ->
+      (match q with
+       | XO q0 -> XI q0
+       | _ -> q)
+  
+  (** val coq_land : positive -> positive -> n **)
+  
+  let rec coq_land p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Nsucc_double (coq_land p0 q0)
+       | XO q0 -> coq_Ndouble (coq_land p0 q0)
+       | XH -> Npos XH)
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (coq_land p0 q0)
+       | XO q0 -> coq_Ndouble (coq_land p0 q0)
+       | XH -> N0)
+    | XH ->
+      (match q with
+       | XO q0 -> N0
+       | _ -> Npos XH)
+  
+  (** val ldiff : positive -> positive -> n **)
+  
+  let rec ldiff p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (ldiff p0 q0)
+       | XO q0 -> coq_Nsucc_double (ldiff p0 q0)
+       | XH -> Npos (XO p0))
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (ldiff p0 q0)
+       | XO q0 -> coq_Ndouble (ldiff p0 q0)
+       | XH -> Npos p)
+    | XH ->
+      (match q with
+       | XO q0 -> Npos XH
+       | _ -> N0)
+  
+  (** val coq_lxor : positive -> positive -> n **)
+  
+  let rec coq_lxor p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (coq_lxor p0 q0)
+       | XO q0 -> coq_Nsucc_double (coq_lxor p0 q0)
+       | XH -> Npos (XO p0))
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Nsucc_double (coq_lxor p0 q0)
+       | XO q0 -> coq_Ndouble (coq_lxor p0 q0)
+       | XH -> Npos (XI p0))
+    | XH ->
+      (match q with
+       | XI q0 -> Npos (XO q0)
+       | XO q0 -> Npos (XI q0)
+       | XH -> N0)
+  
+  (** val shiftl_nat : positive -> int -> positive **)
+  
+  let shiftl_nat p n0 =
+    nat_iter n0 (fun x -> XO x) p
+  
+  (** val shiftr_nat : positive -> int -> positive **)
+  
+  let shiftr_nat p n0 =
+    nat_iter n0 div2 p
+  
+  (** val shiftl : positive -> n -> positive **)
+  
+  let shiftl p = function
+  | N0 -> p
+  | Npos n1 -> iter n1 (fun x -> XO x) p
+  
+  (** val shiftr : positive -> n -> positive **)
+  
+  let shiftr p = function
+  | N0 -> p
+  | Npos n1 -> iter n1 div2 p
+  
+  (** val testbit_nat : positive -> int -> bool **)
+  
+  let rec testbit_nat p n0 =
+    match p with
+    | XI p0 ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         true)
+         (fun n' ->
+         testbit_nat p0 n')
+         n0)
+    | XO p0 ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         false)
+         (fun n' ->
+         testbit_nat p0 n')
+         n0)
+    | XH ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         true)
+         (fun n1 ->
+         false)
+         n0)
+  
+  (** val testbit : positive -> n -> bool **)
+  
+  let rec testbit p n0 =
+    match p with
+    | XI p0 ->
+      (match n0 with
+       | N0 -> true
+       | Npos n1 -> testbit p0 (pred_N n1))
+    | XO p0 ->
+      (match n0 with
+       | N0 -> false
+       | Npos n1 -> testbit p0 (pred_N n1))
+    | XH ->
+      (match n0 with
+       | N0 -> true
+       | Npos p0 -> false)
+  
+  (** val iter_op : ('a1 -> 'a1 -> 'a1) -> positive -> 'a1 -> 'a1 **)
+  
+  let rec iter_op op p a =
+    match p with
+    | XI p0 -> op a (iter_op op p0 (op a a))
+    | XO p0 -> iter_op op p0 (op a a)
+    | XH -> a
+  
+  (** val to_nat : positive -> int **)
+  
+  let to_nat x =
+    iter_op plus x (Pervasives.succ 0)
+  
+  (** val of_nat : int -> positive **)
+  
+  let rec of_nat n0 =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun x ->
+      (fun fO fS n -> if n=0 then fO () else fS (n-1))
+        (fun _ ->
+        XH)
+        (fun n1 ->
+        succ (of_nat x))
+        x)
+      n0
+  
+  (** val of_succ_nat : int -> positive **)
+  
+  let rec of_succ_nat n0 =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun x ->
+      succ (of_succ_nat x))
+      n0
+ end
+
+module Coq_Pos = 
+ struct 
+  type t = positive
+  
+  (** val succ : positive -> positive **)
+  
+  let rec succ = function
+  | XI p -> XO (succ p)
+  | XO p -> XI p
+  | XH -> XO XH
+  
+  (** val add : positive -> positive -> positive **)
+  
+  let rec add x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> XO (add_carry p q)
+       | XO q -> XI (add p q)
+       | XH -> XO (succ p))
+    | XO p ->
+      (match y with
+       | XI q -> XI (add p q)
+       | XO q -> XO (add p q)
+       | XH -> XI p)
+    | XH ->
+      (match y with
+       | XI q -> XO (succ q)
+       | XO q -> XI q
+       | XH -> XO XH)
+  
+  (** val add_carry : positive -> positive -> positive **)
+  
+  and add_carry x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> XI (add_carry p q)
+       | XO q -> XO (add_carry p q)
+       | XH -> XI (succ p))
+    | XO p ->
+      (match y with
+       | XI q -> XO (add_carry p q)
+       | XO q -> XI (add p q)
+       | XH -> XO (succ p))
+    | XH ->
+      (match y with
+       | XI q -> XI (succ q)
+       | XO q -> XO (succ q)
+       | XH -> XI XH)
+  
+  (** val pred_double : positive -> positive **)
+  
+  let rec pred_double = function
+  | XI p -> XI (XO p)
+  | XO p -> XI (pred_double p)
+  | XH -> XH
+  
+  (** val pred : positive -> positive **)
+  
+  let pred = function
+  | XI p -> XO p
+  | XO p -> pred_double p
+  | XH -> XH
+  
+  (** val pred_N : positive -> n **)
+  
+  let pred_N = function
+  | XI p -> Npos (XO p)
+  | XO p -> Npos (pred_double p)
+  | XH -> N0
+  
+  type mask = Pos.mask =
+  | IsNul
+  | IsPos of positive
+  | IsNeg
+  
+  (** val mask_rect : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1 **)
+  
+  let mask_rect f f0 f1 = function
+  | IsNul -> f
+  | IsPos x -> f0 x
+  | IsNeg -> f1
+  
+  (** val mask_rec : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1 **)
+  
+  let mask_rec f f0 f1 = function
+  | IsNul -> f
+  | IsPos x -> f0 x
+  | IsNeg -> f1
+  
+  (** val succ_double_mask : mask -> mask **)
+  
+  let succ_double_mask = function
+  | IsNul -> IsPos XH
+  | IsPos p -> IsPos (XI p)
+  | IsNeg -> IsNeg
+  
+  (** val double_mask : mask -> mask **)
+  
+  let double_mask = function
+  | IsPos p -> IsPos (XO p)
+  | x0 -> x0
+  
+  (** val double_pred_mask : positive -> mask **)
+  
+  let double_pred_mask = function
+  | XI p -> IsPos (XO (XO p))
+  | XO p -> IsPos (XO (pred_double p))
+  | XH -> IsNul
+  
+  (** val pred_mask : mask -> mask **)
+  
+  let pred_mask = function
+  | IsPos q ->
+    (match q with
+     | XH -> IsNul
+     | _ -> IsPos (pred q))
+  | _ -> IsNeg
+  
+  (** val sub_mask : positive -> positive -> mask **)
+  
+  let rec sub_mask x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> double_mask (sub_mask p q)
+       | XO q -> succ_double_mask (sub_mask p q)
+       | XH -> IsPos (XO p))
+    | XO p ->
+      (match y with
+       | XI q -> succ_double_mask (sub_mask_carry p q)
+       | XO q -> double_mask (sub_mask p q)
+       | XH -> IsPos (pred_double p))
+    | XH ->
+      (match y with
+       | XH -> IsNul
+       | _ -> IsNeg)
+  
+  (** val sub_mask_carry : positive -> positive -> mask **)
+  
+  and sub_mask_carry x y =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> succ_double_mask (sub_mask_carry p q)
+       | XO q -> double_mask (sub_mask p q)
+       | XH -> IsPos (pred_double p))
+    | XO p ->
+      (match y with
+       | XI q -> double_mask (sub_mask_carry p q)
+       | XO q -> succ_double_mask (sub_mask_carry p q)
+       | XH -> double_pred_mask p)
+    | XH -> IsNeg
+  
+  (** val sub : positive -> positive -> positive **)
+  
+  let sub x y =
+    match sub_mask x y with
+    | IsPos z -> z
+    | _ -> XH
+  
+  (** val mul : positive -> positive -> positive **)
+  
+  let rec mul x y =
+    match x with
+    | XI p -> add y (XO (mul p y))
+    | XO p -> XO (mul p y)
+    | XH -> y
+  
+  (** val iter : positive -> ('a1 -> 'a1) -> 'a1 -> 'a1 **)
+  
+  let rec iter n0 f x =
+    match n0 with
+    | XI n' -> f (iter n' f (iter n' f x))
+    | XO n' -> iter n' f (iter n' f x)
+    | XH -> f x
+  
+  (** val pow : positive -> positive -> positive **)
+  
+  let pow x y =
+    iter y (mul x) XH
+  
+  (** val square : positive -> positive **)
+  
+  let rec square = function
+  | XI p0 -> XI (XO (add (square p0) p0))
+  | XO p0 -> XO (XO (square p0))
+  | XH -> XH
+  
+  (** val div2 : positive -> positive **)
+  
+  let div2 = function
+  | XI p0 -> p0
+  | XO p0 -> p0
+  | XH -> XH
+  
+  (** val div2_up : positive -> positive **)
+  
+  let div2_up = function
+  | XI p0 -> succ p0
+  | XO p0 -> p0
+  | XH -> XH
+  
+  (** val size_nat : positive -> int **)
+  
+  let rec size_nat = function
+  | XI p0 -> Pervasives.succ (size_nat p0)
+  | XO p0 -> Pervasives.succ (size_nat p0)
+  | XH -> Pervasives.succ 0
+  
+  (** val size : positive -> positive **)
+  
+  let rec size = function
+  | XI p0 -> succ (size p0)
+  | XO p0 -> succ (size p0)
+  | XH -> XH
+  
+  (** val compare_cont : positive -> positive -> comparison -> comparison **)
+  
+  let rec compare_cont x y r =
+    match x with
+    | XI p ->
+      (match y with
+       | XI q -> compare_cont p q r
+       | XO q -> compare_cont p q Gt
+       | XH -> Gt)
+    | XO p ->
+      (match y with
+       | XI q -> compare_cont p q Lt
+       | XO q -> compare_cont p q r
+       | XH -> Gt)
+    | XH ->
+      (match y with
+       | XH -> r
+       | _ -> Lt)
+  
+  (** val compare : positive -> positive -> comparison **)
+  
+  let compare x y =
+    compare_cont x y Eq
+  
+  (** val min : positive -> positive -> positive **)
+  
+  let min p p' =
+    match compare p p' with
+    | Gt -> p'
+    | _ -> p
+  
+  (** val max : positive -> positive -> positive **)
+  
+  let max p p' =
+    match compare p p' with
+    | Gt -> p
+    | _ -> p'
+  
+  (** val eqb : positive -> positive -> bool **)
+  
+  let rec eqb p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> eqb p0 q0
+       | _ -> false)
+    | XO p0 ->
+      (match q with
+       | XO q0 -> eqb p0 q0
+       | _ -> false)
+    | XH ->
+      (match q with
+       | XH -> true
+       | _ -> false)
+  
+  (** val leb : positive -> positive -> bool **)
+  
+  let leb x y =
+    match compare x y with
+    | Gt -> false
+    | _ -> true
+  
+  (** val ltb : positive -> positive -> bool **)
+  
+  let ltb x y =
+    match compare x y with
+    | Lt -> true
+    | _ -> false
+  
+  (** val sqrtrem_step :
+      (positive -> positive) -> (positive -> positive) -> (positive * mask)
+      -> positive * mask **)
+  
+  let sqrtrem_step f g = function
+  | (s, y) ->
+    (match y with
+     | IsPos r ->
+       let s' = XI (XO s) in
+       let r' = g (f r) in
+       if leb s' r' then ((XI s), (sub_mask r' s')) else ((XO s), (IsPos r'))
+     | _ -> ((XO s), (sub_mask (g (f XH)) (XO (XO XH)))))
+  
+  (** val sqrtrem : positive -> positive * mask **)
+  
+  let rec sqrtrem = function
+  | XI p0 ->
+    (match p0 with
+     | XI p1 -> sqrtrem_step (fun x -> XI x) (fun x -> XI x) (sqrtrem p1)
+     | XO p1 -> sqrtrem_step (fun x -> XO x) (fun x -> XI x) (sqrtrem p1)
+     | XH -> (XH, (IsPos (XO XH))))
+  | XO p0 ->
+    (match p0 with
+     | XI p1 -> sqrtrem_step (fun x -> XI x) (fun x -> XO x) (sqrtrem p1)
+     | XO p1 -> sqrtrem_step (fun x -> XO x) (fun x -> XO x) (sqrtrem p1)
+     | XH -> (XH, (IsPos XH)))
+  | XH -> (XH, IsNul)
+  
+  (** val sqrt : positive -> positive **)
+  
+  let sqrt p =
+    fst (sqrtrem p)
+  
+  (** val gcdn : int -> positive -> positive -> positive **)
+  
+  let rec gcdn n0 a b =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun n1 ->
+      match a with
+      | XI a' ->
+        (match b with
+         | XI b' ->
+           (match compare a' b' with
+            | Eq -> a
+            | Lt -> gcdn n1 (sub b' a') a
+            | Gt -> gcdn n1 (sub a' b') b)
+         | XO b0 -> gcdn n1 a b0
+         | XH -> XH)
+      | XO a0 ->
+        (match b with
+         | XI p -> gcdn n1 a0 b
+         | XO b0 -> XO (gcdn n1 a0 b0)
+         | XH -> XH)
+      | XH -> XH)
+      n0
+  
+  (** val gcd : positive -> positive -> positive **)
+  
+  let gcd a b =
+    gcdn (plus (size_nat a) (size_nat b)) a b
+  
+  (** val ggcdn :
+      int -> positive -> positive -> positive * (positive * positive) **)
+  
+  let rec ggcdn n0 a b =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ -> (XH, (a,
+      b)))
+      (fun n1 ->
+      match a with
+      | XI a' ->
+        (match b with
+         | XI b' ->
+           (match compare a' b' with
+            | Eq -> (a, (XH, XH))
+            | Lt ->
+              let (g, p) = ggcdn n1 (sub b' a') a in
+              let (ba, aa) = p in (g, (aa, (add aa (XO ba))))
+            | Gt ->
+              let (g, p) = ggcdn n1 (sub a' b') b in
+              let (ab, bb) = p in (g, ((add bb (XO ab)), bb)))
+         | XO b0 ->
+           let (g, p) = ggcdn n1 a b0 in
+           let (aa, bb) = p in (g, (aa, (XO bb)))
+         | XH -> (XH, (a, XH)))
+      | XO a0 ->
+        (match b with
+         | XI p ->
+           let (g, p0) = ggcdn n1 a0 b in
+           let (aa, bb) = p0 in (g, ((XO aa), bb))
+         | XO b0 -> let (g, p) = ggcdn n1 a0 b0 in ((XO g), p)
+         | XH -> (XH, (a, XH)))
+      | XH -> (XH, (XH, b)))
+      n0
+  
+  (** val ggcd : positive -> positive -> positive * (positive * positive) **)
+  
+  let ggcd a b =
+    ggcdn (plus (size_nat a) (size_nat b)) a b
+  
+  (** val coq_Nsucc_double : n -> n **)
+  
+  let coq_Nsucc_double = function
+  | N0 -> Npos XH
+  | Npos p -> Npos (XI p)
+  
+  (** val coq_Ndouble : n -> n **)
+  
+  let coq_Ndouble = function
+  | N0 -> N0
+  | Npos p -> Npos (XO p)
+  
+  (** val coq_lor : positive -> positive -> positive **)
+  
+  let rec coq_lor p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> XI (coq_lor p0 q0)
+       | XO q0 -> XI (coq_lor p0 q0)
+       | XH -> p)
+    | XO p0 ->
+      (match q with
+       | XI q0 -> XI (coq_lor p0 q0)
+       | XO q0 -> XO (coq_lor p0 q0)
+       | XH -> XI p0)
+    | XH ->
+      (match q with
+       | XO q0 -> XI q0
+       | _ -> q)
+  
+  (** val coq_land : positive -> positive -> n **)
+  
+  let rec coq_land p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Nsucc_double (coq_land p0 q0)
+       | XO q0 -> coq_Ndouble (coq_land p0 q0)
+       | XH -> Npos XH)
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (coq_land p0 q0)
+       | XO q0 -> coq_Ndouble (coq_land p0 q0)
+       | XH -> N0)
+    | XH ->
+      (match q with
+       | XO q0 -> N0
+       | _ -> Npos XH)
+  
+  (** val ldiff : positive -> positive -> n **)
+  
+  let rec ldiff p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (ldiff p0 q0)
+       | XO q0 -> coq_Nsucc_double (ldiff p0 q0)
+       | XH -> Npos (XO p0))
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (ldiff p0 q0)
+       | XO q0 -> coq_Ndouble (ldiff p0 q0)
+       | XH -> Npos p)
+    | XH ->
+      (match q with
+       | XO q0 -> Npos XH
+       | _ -> N0)
+  
+  (** val coq_lxor : positive -> positive -> n **)
+  
+  let rec coq_lxor p q =
+    match p with
+    | XI p0 ->
+      (match q with
+       | XI q0 -> coq_Ndouble (coq_lxor p0 q0)
+       | XO q0 -> coq_Nsucc_double (coq_lxor p0 q0)
+       | XH -> Npos (XO p0))
+    | XO p0 ->
+      (match q with
+       | XI q0 -> coq_Nsucc_double (coq_lxor p0 q0)
+       | XO q0 -> coq_Ndouble (coq_lxor p0 q0)
+       | XH -> Npos (XI p0))
+    | XH ->
+      (match q with
+       | XI q0 -> Npos (XO q0)
+       | XO q0 -> Npos (XI q0)
+       | XH -> N0)
+  
+  (** val shiftl_nat : positive -> int -> positive **)
+  
+  let shiftl_nat p n0 =
+    nat_iter n0 (fun x -> XO x) p
+  
+  (** val shiftr_nat : positive -> int -> positive **)
+  
+  let shiftr_nat p n0 =
+    nat_iter n0 div2 p
+  
+  (** val shiftl : positive -> n -> positive **)
+  
+  let shiftl p = function
+  | N0 -> p
+  | Npos n1 -> iter n1 (fun x -> XO x) p
+  
+  (** val shiftr : positive -> n -> positive **)
+  
+  let shiftr p = function
+  | N0 -> p
+  | Npos n1 -> iter n1 div2 p
+  
+  (** val testbit_nat : positive -> int -> bool **)
+  
+  let rec testbit_nat p n0 =
+    match p with
+    | XI p0 ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         true)
+         (fun n' ->
+         testbit_nat p0 n')
+         n0)
+    | XO p0 ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         false)
+         (fun n' ->
+         testbit_nat p0 n')
+         n0)
+    | XH ->
+      ((fun fO fS n -> if n=0 then fO () else fS (n-1))
+         (fun _ ->
+         true)
+         (fun n1 ->
+         false)
+         n0)
+  
+  (** val testbit : positive -> n -> bool **)
+  
+  let rec testbit p n0 =
+    match p with
+    | XI p0 ->
+      (match n0 with
+       | N0 -> true
+       | Npos n1 -> testbit p0 (pred_N n1))
+    | XO p0 ->
+      (match n0 with
+       | N0 -> false
+       | Npos n1 -> testbit p0 (pred_N n1))
+    | XH ->
+      (match n0 with
+       | N0 -> true
+       | Npos p0 -> false)
+  
+  (** val iter_op : ('a1 -> 'a1 -> 'a1) -> positive -> 'a1 -> 'a1 **)
+  
+  let rec iter_op op p a =
+    match p with
+    | XI p0 -> op a (iter_op op p0 (op a a))
+    | XO p0 -> iter_op op p0 (op a a)
+    | XH -> a
+  
+  (** val to_nat : positive -> int **)
+  
+  let to_nat x =
+    iter_op plus x (Pervasives.succ 0)
+  
+  (** val of_nat : int -> positive **)
+  
+  let rec of_nat n0 =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun x ->
+      (fun fO fS n -> if n=0 then fO () else fS (n-1))
+        (fun _ ->
+        XH)
+        (fun n1 ->
+        succ (of_nat x))
+        x)
+      n0
+  
+  (** val of_succ_nat : int -> positive **)
+  
+  let rec of_succ_nat n0 =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      XH)
+      (fun x ->
+      succ (of_succ_nat x))
+      n0
+  
+  (** val eq_dec : positive -> positive -> bool **)
+  
+  let rec eq_dec p y0 =
+    match p with
+    | XI p0 ->
+      (match y0 with
+       | XI p1 -> eq_dec p0 p1
+       | _ -> false)
+    | XO p0 ->
+      (match y0 with
+       | XO p1 -> eq_dec p0 p1
+       | _ -> false)
+    | XH ->
+      (match y0 with
+       | XH -> true
+       | _ -> false)
+  
+  (** val peano_rect : 'a1 -> (positive -> 'a1 -> 'a1) -> positive -> 'a1 **)
+  
+  let rec peano_rect a f p =
+    let f2 = peano_rect (f XH a) (fun p0 x -> f (succ (XO p0)) (f (XO p0) x))
+    in
+    (match p with
+     | XI q -> f (XO q) (f2 q)
+     | XO q -> f2 q
+     | XH -> a)
+  
+  (** val peano_rec : 'a1 -> (positive -> 'a1 -> 'a1) -> positive -> 'a1 **)
+  
+  let peano_rec =
+    peano_rect
+  
+  type coq_PeanoView =
+  | PeanoOne
+  | PeanoSucc of positive * coq_PeanoView
+  
+  (** val coq_PeanoView_rect :
+      'a1 -> (positive -> coq_PeanoView -> 'a1 -> 'a1) -> positive ->
+      coq_PeanoView -> 'a1 **)
+  
+  let rec coq_PeanoView_rect f f0 p = function
+  | PeanoOne -> f
+  | PeanoSucc (p1, p2) -> f0 p1 p2 (coq_PeanoView_rect f f0 p1 p2)
+  
+  (** val coq_PeanoView_rec :
+      'a1 -> (positive -> coq_PeanoView -> 'a1 -> 'a1) -> positive ->
+      coq_PeanoView -> 'a1 **)
+  
+  let rec coq_PeanoView_rec f f0 p = function
+  | PeanoOne -> f
+  | PeanoSucc (p1, p2) -> f0 p1 p2 (coq_PeanoView_rec f f0 p1 p2)
+  
+  (** val peanoView_xO : positive -> coq_PeanoView -> coq_PeanoView **)
+  
+  let rec peanoView_xO p = function
+  | PeanoOne -> PeanoSucc (XH, PeanoOne)
+  | PeanoSucc (p0, q0) ->
+    PeanoSucc ((succ (XO p0)), (PeanoSucc ((XO p0), (peanoView_xO p0 q0))))
+  
+  (** val peanoView_xI : positive -> coq_PeanoView -> coq_PeanoView **)
+  
+  let rec peanoView_xI p = function
+  | PeanoOne -> PeanoSucc ((succ XH), (PeanoSucc (XH, PeanoOne)))
+  | PeanoSucc (p0, q0) ->
+    PeanoSucc ((succ (XI p0)), (PeanoSucc ((XI p0), (peanoView_xI p0 q0))))
+  
+  (** val peanoView : positive -> coq_PeanoView **)
+  
+  let rec peanoView = function
+  | XI p0 -> peanoView_xI p0 (peanoView p0)
+  | XO p0 -> peanoView_xO p0 (peanoView p0)
+  | XH -> PeanoOne
+  
+  (** val coq_PeanoView_iter :
+      'a1 -> (positive -> 'a1 -> 'a1) -> positive -> coq_PeanoView -> 'a1 **)
+  
+  let rec coq_PeanoView_iter a f p = function
+  | PeanoOne -> a
+  | PeanoSucc (p0, q0) -> f p0 (coq_PeanoView_iter a f p0 q0)
+  
+  (** val eqb_spec : positive -> positive -> reflect **)
+  
+  let eqb_spec x y =
+    iff_reflect (eqb x y)
+  
+  (** val switch_Eq : comparison -> comparison -> comparison **)
+  
+  let switch_Eq c = function
+  | Eq -> c
+  | x -> x
+  
+  (** val mask2cmp : mask -> comparison **)
+  
+  let mask2cmp = function
+  | IsNul -> Eq
+  | IsPos p0 -> Gt
+  | IsNeg -> Lt
+  
+  (** val leb_spec0 : positive -> positive -> reflect **)
+  
+  let leb_spec0 x y =
+    iff_reflect (leb x y)
+  
+  (** val ltb_spec0 : positive -> positive -> reflect **)
+  
+  let ltb_spec0 x y =
+    iff_reflect (ltb x y)
+  
+  module Private_Tac = 
+   struct 
+    
+   end
+  
+  module Private_Dec = 
+   struct 
+    (** val max_case_strong :
+        positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+        (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+    
+    let max_case_strong n0 m compat hl hr =
+      let c = compSpec2Type n0 m (compare n0 m) in
+      (match c with
+       | CompGtT -> compat n0 (max n0 m) __ (hl __)
+       | _ -> compat m (max n0 m) __ (hr __))
+    
+    (** val max_case :
+        positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+        'a1 -> 'a1 -> 'a1 **)
+    
+    let max_case n0 m x x0 x1 =
+      max_case_strong n0 m x (fun _ -> x0) (fun _ -> x1)
+    
+    (** val max_dec : positive -> positive -> bool **)
+    
+    let max_dec n0 m =
+      max_case n0 m (fun x y _ h0 -> h0) true false
+    
+    (** val min_case_strong :
+        positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+        (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+    
+    let min_case_strong n0 m compat hl hr =
+      let c = compSpec2Type n0 m (compare n0 m) in
+      (match c with
+       | CompGtT -> compat m (min n0 m) __ (hr __)
+       | _ -> compat n0 (min n0 m) __ (hl __))
+    
+    (** val min_case :
+        positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+        'a1 -> 'a1 -> 'a1 **)
+    
+    let min_case n0 m x x0 x1 =
+      min_case_strong n0 m x (fun _ -> x0) (fun _ -> x1)
+    
+    (** val min_dec : positive -> positive -> bool **)
+    
+    let min_dec n0 m =
+      min_case n0 m (fun x y _ h0 -> h0) true false
+   end
+  
+  (** val max_case_strong :
+      positive -> positive -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+  
+  let max_case_strong n0 m x x0 =
+    Private_Dec.max_case_strong n0 m (fun x1 y _ x2 -> x2) x x0
+  
+  (** val max_case : positive -> positive -> 'a1 -> 'a1 -> 'a1 **)
+  
+  let max_case n0 m x x0 =
+    max_case_strong n0 m (fun _ -> x) (fun _ -> x0)
+  
+  (** val max_dec : positive -> positive -> bool **)
+  
+  let max_dec =
+    Private_Dec.max_dec
+  
+  (** val min_case_strong :
+      positive -> positive -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+  
+  let min_case_strong n0 m x x0 =
+    Private_Dec.min_case_strong n0 m (fun x1 y _ x2 -> x2) x x0
+  
+  (** val min_case : positive -> positive -> 'a1 -> 'a1 -> 'a1 **)
+  
+  let min_case n0 m x x0 =
+    min_case_strong n0 m (fun _ -> x) (fun _ -> x0)
+  
+  (** val min_dec : positive -> positive -> bool **)
+  
+  let min_dec =
+    Private_Dec.min_dec
+ end
+
+module N = 
+ struct 
+  type t = n
+  
+  (** val zero : n **)
+  
+  let zero =
+    N0
+  
+  (** val one : n **)
+  
+  let one =
+    Npos XH
+  
+  (** val two : n **)
+  
+  let two =
+    Npos (XO XH)
+  
+  (** val succ_double : n -> n **)
+  
+  let succ_double = function
+  | N0 -> Npos XH
+  | Npos p -> Npos (XI p)
+  
+  (** val double : n -> n **)
+  
+  let double = function
+  | N0 -> N0
+  | Npos p -> Npos (XO p)
+  
+  (** val succ : n -> n **)
+  
+  let succ = function
+  | N0 -> Npos XH
+  | Npos p -> Npos (Coq_Pos.succ p)
+  
+  (** val pred : n -> n **)
+  
+  let pred = function
+  | N0 -> N0
+  | Npos p -> Coq_Pos.pred_N p
+  
+  (** val succ_pos : n -> positive **)
+  
+  let succ_pos = function
+  | N0 -> XH
+  | Npos p -> Coq_Pos.succ p
+  
+  (** val add : n -> n -> n **)
+  
+  let add n0 m =
+    match n0 with
     | N0 -> m
-    | Npos p -> (match m with
-                   | N0 -> n0
-                   | Npos q -> Npos (pplus p q))
-
-(** val nmult : n -> n -> n **)
-
-let nmult n0 m =
-  match n0 with
+    | Npos p ->
+      (match m with
+       | N0 -> n0
+       | Npos q -> Npos (Coq_Pos.add p q))
+  
+  (** val sub : n -> n -> n **)
+  
+  let sub n0 m =
+    match n0 with
     | N0 -> N0
-    | Npos p -> (match m with
-                   | N0 -> N0
-                   | Npos q -> Npos (pmult p q))
-
-(** val nat_of_N : n -> int **)
-
-let nat_of_N = function
+    | Npos n' ->
+      (match m with
+       | N0 -> n0
+       | Npos m' ->
+         (match Coq_Pos.sub_mask n' m' with
+          | Coq_Pos.IsPos p -> Npos p
+          | _ -> N0))
+  
+  (** val mul : n -> n -> n **)
+  
+  let mul n0 m =
+    match n0 with
+    | N0 -> N0
+    | Npos p ->
+      (match m with
+       | N0 -> N0
+       | Npos q -> Npos (Coq_Pos.mul p q))
+  
+  (** val compare : n -> n -> comparison **)
+  
+  let compare n0 m =
+    match n0 with
+    | N0 ->
+      (match m with
+       | N0 -> Eq
+       | Npos m' -> Lt)
+    | Npos n' ->
+      (match m with
+       | N0 -> Gt
+       | Npos m' -> Coq_Pos.compare n' m')
+  
+  (** val eqb : n -> n -> bool **)
+  
+  let rec eqb n0 m =
+    match n0 with
+    | N0 ->
+      (match m with
+       | N0 -> true
+       | Npos p -> false)
+    | Npos p ->
+      (match m with
+       | N0 -> false
+       | Npos q -> Coq_Pos.eqb p q)
+  
+  (** val leb : n -> n -> bool **)
+  
+  let leb x y =
+    match compare x y with
+    | Gt -> false
+    | _ -> true
+  
+  (** val ltb : n -> n -> bool **)
+  
+  let ltb x y =
+    match compare x y with
+    | Lt -> true
+    | _ -> false
+  
+  (** val min : n -> n -> n **)
+  
+  let min n0 n' =
+    match compare n0 n' with
+    | Gt -> n'
+    | _ -> n0
+  
+  (** val max : n -> n -> n **)
+  
+  let max n0 n' =
+    match compare n0 n' with
+    | Gt -> n0
+    | _ -> n'
+  
+  (** val div2 : n -> n **)
+  
+  let div2 = function
+  | N0 -> N0
+  | Npos p0 ->
+    (match p0 with
+     | XI p -> Npos p
+     | XO p -> Npos p
+     | XH -> N0)
+  
+  (** val even : n -> bool **)
+  
+  let even = function
+  | N0 -> true
+  | Npos p ->
+    (match p with
+     | XO p0 -> true
+     | _ -> false)
+  
+  (** val odd : n -> bool **)
+  
+  let odd n0 =
+    negb (even n0)
+  
+  (** val pow : n -> n -> n **)
+  
+  let pow n0 = function
+  | N0 -> Npos XH
+  | Npos p0 ->
+    (match n0 with
+     | N0 -> N0
+     | Npos q -> Npos (Coq_Pos.pow q p0))
+  
+  (** val square : n -> n **)
+  
+  let square = function
+  | N0 -> N0
+  | Npos p -> Npos (Coq_Pos.square p)
+  
+  (** val log2 : n -> n **)
+  
+  let log2 = function
+  | N0 -> N0
+  | Npos p0 ->
+    (match p0 with
+     | XI p -> Npos (Coq_Pos.size p)
+     | XO p -> Npos (Coq_Pos.size p)
+     | XH -> N0)
+  
+  (** val size : n -> n **)
+  
+  let size = function
+  | N0 -> N0
+  | Npos p -> Npos (Coq_Pos.size p)
+  
+  (** val size_nat : n -> int **)
+  
+  let size_nat = function
   | N0 -> 0
-  | Npos p -> nat_of_P p
-
-(** val n_of_nat : int -> n **)
-
-let n_of_nat n0 =
-  (fun fO fS n -> if n=0 then fO () else fS (n-1))
-    (fun _ -> N0)
-    (fun n' -> Npos (p_of_succ_nat n'))
-    n0
+  | Npos p -> Coq_Pos.size_nat p
+  
+  (** val pos_div_eucl : positive -> n -> n * n **)
+  
+  let rec pos_div_eucl a b =
+    match a with
+    | XI a' ->
+      let (q, r) = pos_div_eucl a' b in
+      let r' = succ_double r in
+      if leb b r' then ((succ_double q), (sub r' b)) else ((double q), r')
+    | XO a' ->
+      let (q, r) = pos_div_eucl a' b in
+      let r' = double r in
+      if leb b r' then ((succ_double q), (sub r' b)) else ((double q), r')
+    | XH ->
+      (match b with
+       | N0 -> (N0, (Npos XH))
+       | Npos p ->
+         (match p with
+          | XH -> ((Npos XH), N0)
+          | _ -> (N0, (Npos XH))))
+  
+  (** val div_eucl : n -> n -> n * n **)
+  
+  let div_eucl a b =
+    match a with
+    | N0 -> (N0, N0)
+    | Npos na ->
+      (match b with
+       | N0 -> (N0, a)
+       | Npos p -> pos_div_eucl na b)
+  
+  (** val div : n -> n -> n **)
+  
+  let div a b =
+    fst (div_eucl a b)
+  
+  (** val modulo : n -> n -> n **)
+  
+  let modulo a b =
+    snd (div_eucl a b)
+  
+  (** val gcd : n -> n -> n **)
+  
+  let gcd a b =
+    match a with
+    | N0 -> b
+    | Npos p ->
+      (match b with
+       | N0 -> a
+       | Npos q -> Npos (Coq_Pos.gcd p q))
+  
+  (** val ggcd : n -> n -> n * (n * n) **)
+  
+  let ggcd a b =
+    match a with
+    | N0 -> (b, (N0, (Npos XH)))
+    | Npos p ->
+      (match b with
+       | N0 -> (a, ((Npos XH), N0))
+       | Npos q ->
+         let (g, p0) = Coq_Pos.ggcd p q in
+         let (aa, bb) = p0 in ((Npos g), ((Npos aa), (Npos bb))))
+  
+  (** val sqrtrem : n -> n * n **)
+  
+  let sqrtrem = function
+  | N0 -> (N0, N0)
+  | Npos p ->
+    let (s, m) = Coq_Pos.sqrtrem p in
+    (match m with
+     | Coq_Pos.IsPos r -> ((Npos s), (Npos r))
+     | _ -> ((Npos s), N0))
+  
+  (** val sqrt : n -> n **)
+  
+  let sqrt = function
+  | N0 -> N0
+  | Npos p -> Npos (Coq_Pos.sqrt p)
+  
+  (** val coq_lor : n -> n -> n **)
+  
+  let coq_lor n0 m =
+    match n0 with
+    | N0 -> m
+    | Npos p ->
+      (match m with
+       | N0 -> n0
+       | Npos q -> Npos (Coq_Pos.coq_lor p q))
+  
+  (** val coq_land : n -> n -> n **)
+  
+  let coq_land n0 m =
+    match n0 with
+    | N0 -> N0
+    | Npos p ->
+      (match m with
+       | N0 -> N0
+       | Npos q -> Coq_Pos.coq_land p q)
+  
+  (** val ldiff : n -> n -> n **)
+  
+  let rec ldiff n0 m =
+    match n0 with
+    | N0 -> N0
+    | Npos p ->
+      (match m with
+       | N0 -> n0
+       | Npos q -> Coq_Pos.ldiff p q)
+  
+  (** val coq_lxor : n -> n -> n **)
+  
+  let coq_lxor n0 m =
+    match n0 with
+    | N0 -> m
+    | Npos p ->
+      (match m with
+       | N0 -> n0
+       | Npos q -> Coq_Pos.coq_lxor p q)
+  
+  (** val shiftl_nat : n -> int -> n **)
+  
+  let shiftl_nat a n0 =
+    nat_iter n0 double a
+  
+  (** val shiftr_nat : n -> int -> n **)
+  
+  let shiftr_nat a n0 =
+    nat_iter n0 div2 a
+  
+  (** val shiftl : n -> n -> n **)
+  
+  let shiftl a n0 =
+    match a with
+    | N0 -> N0
+    | Npos a0 -> Npos (Coq_Pos.shiftl a0 n0)
+  
+  (** val shiftr : n -> n -> n **)
+  
+  let shiftr a = function
+  | N0 -> a
+  | Npos p -> Coq_Pos.iter p div2 a
+  
+  (** val testbit_nat : n -> int -> bool **)
+  
+  let testbit_nat = function
+  | N0 -> (fun x -> false)
+  | Npos p -> Coq_Pos.testbit_nat p
+  
+  (** val testbit : n -> n -> bool **)
+  
+  let testbit a n0 =
+    match a with
+    | N0 -> false
+    | Npos p -> Coq_Pos.testbit p n0
+  
+  (** val to_nat : n -> int **)
+  
+  let to_nat = function
+  | N0 -> 0
+  | Npos p -> Coq_Pos.to_nat p
+  
+  (** val of_nat : int -> n **)
+  
+  let of_nat n0 =
+    (fun fO fS n -> if n=0 then fO () else fS (n-1))
+      (fun _ ->
+      N0)
+      (fun n' -> Npos
+      (Coq_Pos.of_succ_nat n'))
+      n0
+  
+  (** val iter : n -> ('a1 -> 'a1) -> 'a1 -> 'a1 **)
+  
+  let iter n0 f x =
+    match n0 with
+    | N0 -> x
+    | Npos p -> Coq_Pos.iter p f x
+  
+  (** val eq_dec : n -> n -> bool **)
+  
+  let eq_dec n0 m =
+    match n0 with
+    | N0 ->
+      (match m with
+       | N0 -> true
+       | Npos p -> false)
+    | Npos x ->
+      (match m with
+       | N0 -> false
+       | Npos p0 -> Coq_Pos.eq_dec x p0)
+  
+  (** val discr : n -> positive option **)
+  
+  let discr = function
+  | N0 -> None
+  | Npos p -> Some p
+  
+  (** val binary_rect :
+      'a1 -> (n -> 'a1 -> 'a1) -> (n -> 'a1 -> 'a1) -> n -> 'a1 **)
+  
+  let binary_rect f0 f2 fS2 n0 =
+    let f2' = fun p -> f2 (Npos p) in
+    let fS2' = fun p -> fS2 (Npos p) in
+    (match n0 with
+     | N0 -> f0
+     | Npos p ->
+       let rec f = function
+       | XI p1 -> fS2' p1 (f p1)
+       | XO p1 -> f2' p1 (f p1)
+       | XH -> fS2 N0 f0
+       in f p)
+  
+  (** val binary_rec :
+      'a1 -> (n -> 'a1 -> 'a1) -> (n -> 'a1 -> 'a1) -> n -> 'a1 **)
+  
+  let binary_rec =
+    binary_rect
+  
+  (** val peano_rect : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1 **)
+  
+  let peano_rect f0 f n0 =
+    let f' = fun p -> f (Npos p) in
+    (match n0 with
+     | N0 -> f0
+     | Npos p -> Coq_Pos.peano_rect (f N0 f0) f' p)
+  
+  (** val peano_rec : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1 **)
+  
+  let peano_rec =
+    peano_rect
+  
+  (** val leb_spec0 : n -> n -> reflect **)
+  
+  let leb_spec0 x y =
+    iff_reflect (leb x y)
+  
+  (** val ltb_spec0 : n -> n -> reflect **)
+  
+  let ltb_spec0 x y =
+    iff_reflect (ltb x y)
+  
+  module Private_BootStrap = 
+   struct 
+    
+   end
+  
+  (** val recursion : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1 **)
+  
+  let recursion x =
+    peano_rect x
+  
+  module Private_OrderTac = 
+   struct 
+    module IsTotal = 
+     struct 
+      
+     end
+    
+    module Tac = 
+     struct 
+      
+     end
+   end
+  
+  module Private_NZPow = 
+   struct 
+    
+   end
+  
+  module Private_NZSqrt = 
+   struct 
+    
+   end
+  
+  (** val sqrt_up : n -> n **)
+  
+  let sqrt_up a =
+    match compare N0 a with
+    | Lt -> succ (sqrt (pred a))
+    | _ -> N0
+  
+  (** val log2_up : n -> n **)
+  
+  let log2_up a =
+    match compare (Npos XH) a with
+    | Lt -> succ (log2 (pred a))
+    | _ -> N0
+  
+  module Private_NZDiv = 
+   struct 
+    
+   end
+  
+  (** val lcm : n -> n -> n **)
+  
+  let lcm a b =
+    mul a (div b (gcd a b))
+  
+  (** val eqb_spec : n -> n -> reflect **)
+  
+  let eqb_spec x y =
+    iff_reflect (eqb x y)
+  
+  (** val b2n : bool -> n **)
+  
+  let b2n = function
+  | true -> Npos XH
+  | false -> N0
+  
+  (** val setbit : n -> n -> n **)
+  
+  let setbit a n0 =
+    coq_lor a (shiftl (Npos XH) n0)
+  
+  (** val clearbit : n -> n -> n **)
+  
+  let clearbit a n0 =
+    ldiff a (shiftl (Npos XH) n0)
+  
+  (** val ones : n -> n **)
+  
+  let ones n0 =
+    pred (shiftl (Npos XH) n0)
+  
+  (** val lnot : n -> n -> n **)
+  
+  let lnot a n0 =
+    coq_lxor a (ones n0)
+  
+  module Private_Tac = 
+   struct 
+    
+   end
+  
+  module Private_Dec = 
+   struct 
+    (** val max_case_strong :
+        n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> (__ -> 'a1) -> (__ -> 'a1)
+        -> 'a1 **)
+    
+    let max_case_strong n0 m compat hl hr =
+      let c = compSpec2Type n0 m (compare n0 m) in
+      (match c with
+       | CompGtT -> compat n0 (max n0 m) __ (hl __)
+       | _ -> compat m (max n0 m) __ (hr __))
+    
+    (** val max_case :
+        n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> 'a1 -> 'a1 -> 'a1 **)
+    
+    let max_case n0 m x x0 x1 =
+      max_case_strong n0 m x (fun _ -> x0) (fun _ -> x1)
+    
+    (** val max_dec : n -> n -> bool **)
+    
+    let max_dec n0 m =
+      max_case n0 m (fun x y _ h0 -> h0) true false
+    
+    (** val min_case_strong :
+        n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> (__ -> 'a1) -> (__ -> 'a1)
+        -> 'a1 **)
+    
+    let min_case_strong n0 m compat hl hr =
+      let c = compSpec2Type n0 m (compare n0 m) in
+      (match c with
+       | CompGtT -> compat m (min n0 m) __ (hr __)
+       | _ -> compat n0 (min n0 m) __ (hl __))
+    
+    (** val min_case :
+        n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> 'a1 -> 'a1 -> 'a1 **)
+    
+    let min_case n0 m x x0 x1 =
+      min_case_strong n0 m x (fun _ -> x0) (fun _ -> x1)
+    
+    (** val min_dec : n -> n -> bool **)
+    
+    let min_dec n0 m =
+      min_case n0 m (fun x y _ h0 -> h0) true false
+   end
+  
+  (** val max_case_strong : n -> n -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+  
+  let max_case_strong n0 m x x0 =
+    Private_Dec.max_case_strong n0 m (fun x1 y _ x2 -> x2) x x0
+  
+  (** val max_case : n -> n -> 'a1 -> 'a1 -> 'a1 **)
+  
+  let max_case n0 m x x0 =
+    max_case_strong n0 m (fun _ -> x) (fun _ -> x0)
+  
+  (** val max_dec : n -> n -> bool **)
+  
+  let max_dec =
+    Private_Dec.max_dec
+  
+  (** val min_case_strong : n -> n -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1 **)
+  
+  let min_case_strong n0 m x x0 =
+    Private_Dec.min_case_strong n0 m (fun x1 y _ x2 -> x2) x x0
+  
+  (** val min_case : n -> n -> 'a1 -> 'a1 -> 'a1 **)
+  
+  let min_case n0 m x x0 =
+    min_case_strong n0 m (fun _ -> x) (fun _ -> x0)
+  
+  (** val min_dec : n -> n -> bool **)
+  
+  let min_dec =
+    Private_Dec.min_dec
+ end
 
 (** val flat_map : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list **)
 
 let rec flat_map f = function
-  | [] -> []
-  | x::t -> app (f x) (flat_map f t)
+| [] -> []
+| x::t0 -> app (f x) (flat_map f t0)
 
 (** val eucl_dev : int -> int -> (int * int) **)
 
 let eucl_dev = fun n m -> (m/n, m mod n)
 
 type ascii =
-  | Ascii of bool * bool * bool * bool * bool * bool * bool * bool
+| Ascii of bool * bool * bool * bool * bool * bool * bool * bool
 
-(** val zero : ascii **)
+(** val zero0 : ascii **)
 
-let zero =
+let zero0 =
   Ascii (false, false, false, false, false, false, false, false)
 
-(** val one : ascii **)
+(** val one0 : ascii **)
 
-let one =
+let one0 =
   Ascii (true, false, false, false, false, false, false, false)
 
 (** val shift : bool -> ascii -> ascii **)
 
 let shift c = function
-  | Ascii (a1, a2, a3, a4, a5, a6, a7, a8) -> Ascii (c, a1, a2, a3, a4, a5,
-      a6, a7)
+| Ascii (a1, a2, a3, a4, a5, a6, a7, a8) ->
+  Ascii (c, a1, a2, a3, a4, a5, a6, a7)
 
 (** val ascii_of_pos : positive -> ascii **)
 
 let ascii_of_pos =
   let rec loop n0 p =
     (fun fO fS n -> if n=0 then fO () else fS (n-1))
-      (fun _ -> zero)
+      (fun _ ->
+      zero0)
       (fun n' ->
       match p with
-        | XI p' -> shift true (loop n' p')
-        | XO p' -> shift false (loop n' p')
-        | XH -> one)
+      | XI p' -> shift true (loop n' p')
+      | XO p' -> shift false (loop n' p')
+      | XH -> one0)
       n0
-  in loop (succ (succ (succ (succ (succ (succ (succ (succ 0))))))))
+  in loop (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+       (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+       0))))))))
 
 (** val ascii_of_N : n -> ascii **)
 
 let ascii_of_N = function
-  | N0 -> zero
-  | Npos p -> ascii_of_pos p
+| N0 -> zero0
+| Npos p -> ascii_of_pos p
 
 (** val ascii_of_nat : int -> ascii **)
 
 let ascii_of_nat a =
-  ascii_of_N (n_of_nat a)
+  ascii_of_N (N.of_nat a)
 
 (** val n_of_digits : bool list -> n **)
 
 let rec n_of_digits = function
-  | [] -> N0
-  | b::l' ->
-      nplus (if b then Npos XH else N0)
-        (nmult (Npos (XO XH)) (n_of_digits l'))
+| [] -> N0
+| b::l' ->
+  N.add (if b then Npos XH else N0) (N.mul (Npos (XO XH)) (n_of_digits l'))
 
 (** val n_of_ascii : ascii -> n **)
 
 let n_of_ascii = function
-  | Ascii (a0, a1, a2, a3, a4, a5, a6, a7) ->
-      n_of_digits (a0::(a1::(a2::(a3::(a4::(a5::(a6::(a7::[]))))))))
+| Ascii (a0, a1, a2, a3, a4, a5, a6, a7) ->
+  n_of_digits (a0::(a1::(a2::(a3::(a4::(a5::(a6::(a7::[]))))))))
 
 (** val nat_of_ascii : ascii -> int **)
 
 let nat_of_ascii a =
-  nat_of_N (n_of_ascii a)
+  N.to_nat (n_of_ascii a)
 
 (** val take : int -> 'a1 list -> 'a1 list **)
 
 let rec take n0 xs =
   (fun fO fS n -> if n=0 then fO () else fS (n-1))
-    (fun _ -> [])
-    (fun m -> match xs with
-                | [] -> []
-                | x::xs0 -> x::(take m xs0))
+    (fun _ ->
+    [])
+    (fun m ->
+    match xs with
+    | [] -> []
+    | x::xs0 -> x::(take m xs0))
     n0
 
 (** val drop : int -> 'a1 list -> 'a1 list **)
 
 let rec drop n0 xs =
   (fun fO fS n -> if n=0 then fO () else fS (n-1))
-    (fun _ -> xs)
-    (fun m -> match xs with
-                | [] -> []
-                | x::xs0 -> drop m xs0)
+    (fun _ ->
+    xs)
+    (fun m ->
+    match xs with
+    | [] -> []
+    | x::xs0 -> drop m xs0)
     n0
 
 (** val split_at : int -> 'a1 list -> 'a1 list * 'a1 list **)
@@ -249,17 +2164,20 @@ let split_at n0 xs =
 (** val pair : 'a1 list -> ('a1 * 'a1) list **)
 
 let rec pair = function
-  | [] -> []
-  | k::l -> (match l with
-               | [] -> []
-               | v::ys -> (k, v)::(pair ys))
+| [] -> []
+| k::l ->
+  (match l with
+   | [] -> []
+   | v::ys -> (k, v)::(pair ys))
 
-(** val pow : int -> int **)
+(** val pow0 : int -> int **)
 
-let rec pow n0 =
+let rec pow0 n0 =
   (fun fO fS n -> if n=0 then fO () else fS (n-1))
-    (fun _ -> succ 0)
-    (fun n' -> mult (succ (succ 0)) (pow n'))
+    (fun _ -> Pervasives.succ
+    0)
+    (fun n' ->
+    mult (Pervasives.succ (Pervasives.succ 0)) (pow0 n'))
     n0
 
 (** val divmod : int -> int -> (int * int) **)
@@ -289,38 +2207,47 @@ let ascii8_of_nat =
 
 let ascii16_of_nat a =
   let (q, r) =
-    divmod a (pow (succ (succ (succ (succ (succ (succ (succ (succ 0)))))))))
+    divmod a
+      (pow0 (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ 0)))))))))
   in
   ((ascii8_of_nat q), (ascii8_of_nat r))
 
 (** val nat_of_ascii16 : ascii16 -> int **)
 
 let nat_of_ascii16 = function
-  | (a1, a2) ->
-      plus
-        (mult (nat_of_ascii8 a1)
-          (pow (succ (succ (succ (succ (succ (succ (succ (succ 0))))))))))
-        (nat_of_ascii8 a2)
+| (a1, a2) ->
+  plus
+    (mult (nat_of_ascii8 a1)
+      (pow0 (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ 0)))))))))) (nat_of_ascii8 a2)
 
 (** val ascii32_of_nat : int -> (ascii * ascii) * (ascii * ascii) **)
 
 let ascii32_of_nat a =
   let (q, r) =
     divmod a
-      (pow (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ
-        (succ (succ (succ (succ (succ 0)))))))))))))))))
+      (pow0 (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ 0)))))))))))))))))
   in
   ((ascii16_of_nat q), (ascii16_of_nat r))
 
 (** val nat_of_ascii32 : ascii32 -> int **)
 
 let nat_of_ascii32 = function
-  | (a1, a2) ->
-      plus
-        (mult (nat_of_ascii16 a1)
-          (pow (succ (succ (succ (succ (succ (succ (succ (succ (succ (succ
-            (succ (succ (succ (succ (succ (succ 0))))))))))))))))))
-        (nat_of_ascii16 a2)
+| (a1, a2) ->
+  plus
+    (mult (nat_of_ascii16 a1)
+      (pow0 (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ (Pervasives.succ (Pervasives.succ (Pervasives.succ
+        (Pervasives.succ 0)))))))))))))))))) (nat_of_ascii16 a2)
 
 (** val list_of_ascii8 : ascii8 -> ascii8 list **)
 
@@ -330,42 +2257,42 @@ let list_of_ascii8 x =
 (** val list_of_ascii16 : ascii16 -> ascii8 list **)
 
 let list_of_ascii16 = function
-  | (x1, x2) -> app (list_of_ascii8 x1) (list_of_ascii8 x2)
+| (x1, x2) -> app (list_of_ascii8 x1) (list_of_ascii8 x2)
 
 (** val list_of_ascii32 : ascii32 -> ascii8 list **)
 
 let list_of_ascii32 = function
-  | (x1, x2) -> app (list_of_ascii16 x1) (list_of_ascii16 x2)
+| (x1, x2) -> app (list_of_ascii16 x1) (list_of_ascii16 x2)
 
 (** val list_of_ascii64 : ascii64 -> ascii8 list **)
 
 let list_of_ascii64 = function
-  | (x1, x2) -> app (list_of_ascii32 x1) (list_of_ascii32 x2)
+| (x1, x2) -> app (list_of_ascii32 x1) (list_of_ascii32 x2)
 
 type object0 =
-  | Bool of bool
-  | Nil
-  | PFixnum of ascii8
-  | NFixnum of ascii8
-  | Uint8 of ascii8
-  | Uint16 of ascii16
-  | Uint32 of ascii32
-  | Uint64 of ascii64
-  | Int8 of ascii8
-  | Int16 of ascii16
-  | Int32 of ascii32
-  | Int64 of ascii64
-  | Float of ascii32
-  | Double of ascii64
-  | FixRaw of ascii8 list
-  | Raw16 of ascii8 list
-  | Raw32 of ascii8 list
-  | FixArray of object0 list
-  | Array16 of object0 list
-  | Array32 of object0 list
-  | FixMap of (object0 * object0) list
-  | Map16 of (object0 * object0) list
-  | Map32 of (object0 * object0) list
+| Bool of bool
+| Nil
+| PFixnum of ascii8
+| NFixnum of ascii8
+| Uint8 of ascii8
+| Uint16 of ascii16
+| Uint32 of ascii32
+| Uint64 of ascii64
+| Int8 of ascii8
+| Int16 of ascii16
+| Int32 of ascii32
+| Int64 of ascii64
+| Float of ascii32
+| Double of ascii64
+| FixRaw of ascii8 list
+| Raw16 of ascii8 list
+| Raw32 of ascii8 list
+| FixArray of object0 list
+| Array16 of object0 list
+| Array32 of object0 list
+| FixMap of (object0 * object0) list
+| Map16 of (object0 * object0) list
+| Map32 of (object0 * object0) list
 
 (** val atat : ('a1 -> 'a2) -> 'a1 -> 'a2 **)
 
@@ -375,101 +2302,101 @@ let atat f x =
 (** val serialize : object0 -> ascii8 list **)
 
 let rec serialize = function
-  | Bool b ->
-      if b
-      then (Ascii (true, true, false, false, false, false, true, true))::[]
-      else (Ascii (false, true, false, false, false, false, true, true))::[]
-  | Nil -> (Ascii (false, false, false, false, false, false, true, true))::[]
-  | PFixnum a ->
-      let Ascii (b1, b2, b3, b4, b5, b6, b7, b) = a in
-      (Ascii (b1, b2, b3, b4, b5, b6, b7, false))::[]
-  | NFixnum a ->
-      let Ascii (b1, b2, b3, b4, b5, b, b0, b6) = a in
-      (Ascii (b1, b2, b3, b4, b5, true, true, true))::[]
-  | Uint8 c -> (Ascii (false, false, true, true, false, false, true,
-      true))::(list_of_ascii8 c)
-  | Uint16 c -> (Ascii (true, false, true, true, false, false, true,
-      true))::(list_of_ascii16 c)
-  | Uint32 c -> (Ascii (false, true, true, true, false, false, true,
-      true))::(list_of_ascii32 c)
-  | Uint64 c -> (Ascii (true, true, true, true, false, false, true,
-      true))::(list_of_ascii64 c)
-  | Int8 c -> (Ascii (false, false, false, false, true, false, true,
-      true))::(list_of_ascii8 c)
-  | Int16 c -> (Ascii (true, false, false, false, true, false, true,
-      true))::(list_of_ascii16 c)
-  | Int32 c -> (Ascii (false, true, false, false, true, false, true,
-      true))::(list_of_ascii32 c)
-  | Int64 c -> (Ascii (true, true, false, false, true, false, true,
-      true))::(list_of_ascii64 c)
-  | Float c -> (Ascii (false, true, false, true, false, false, true,
-      true))::(list_of_ascii32 c)
-  | Double c -> (Ascii (true, true, false, true, false, false, true,
-      true))::(list_of_ascii64 c)
-  | FixRaw xs ->
-      let Ascii (b1, b2, b3, b4, b5, b, b0, b6) =
-        atat ascii8_of_nat (length xs)
-      in
-      (Ascii (b1, b2, b3, b4, b5, true, false, true))::xs
-  | Raw16 xs ->
-      let (s1, s2) = atat ascii16_of_nat (length xs) in
-      (Ascii (false, true, false, true, true, false, true,
-      true))::(s1::(s2::xs))
-  | Raw32 xs ->
-      let (p, p0) = atat ascii32_of_nat (length xs) in
-      let (s1, s2) = p in
-      let (s3, s4) = p0 in
-      (Ascii (true, true, false, true, true, false, true,
-      true))::(s1::(s2::(s3::(s4::xs))))
-  | FixArray xs ->
-      let ys = flat_map serialize xs in
-      let Ascii (b1, b2, b3, b4, b, b0, b5, b6) =
-        atat ascii8_of_nat (length xs)
-      in
-      (Ascii (b1, b2, b3, b4, true, false, false, true))::ys
-  | Array16 xs ->
-      let ys = flat_map serialize xs in
-      let (s1, s2) = ascii16_of_nat (length xs) in
-      (Ascii (false, false, true, true, true, false, true,
-      true))::(s1::(s2::ys))
-  | Array32 xs ->
-      let ys = flat_map serialize xs in
-      let (p, p0) = atat ascii32_of_nat (length xs) in
-      let (s1, s2) = p in
-      let (s3, s4) = p0 in
-      (Ascii (true, false, true, true, true, false, true,
-      true))::(s1::(s2::(s3::(s4::ys))))
-  | FixMap xs ->
-      let ys =
-        flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
-      in
-      let Ascii (b1, b2, b3, b4, b, b0, b5, b6) =
-        atat ascii8_of_nat (length xs)
-      in
-      (Ascii (b1, b2, b3, b4, false, false, false, true))::ys
-  | Map16 xs ->
-      let ys =
-        flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
-      in
-      let (s1, s2) = ascii16_of_nat (length xs) in
-      (Ascii (false, true, true, true, true, false, true,
-      true))::(s1::(s2::ys))
-  | Map32 xs ->
-      let ys =
-        flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
-      in
-      let (p, p0) = atat ascii32_of_nat (length xs) in
-      let (s1, s2) = p in
-      let (s3, s4) = p0 in
-      (Ascii (true, true, true, true, true, false, true,
-      true))::(s1::(s2::(s3::(s4::ys))))
+| Bool b ->
+  if b
+  then (Ascii (true, true, false, false, false, false, true, true))::[]
+  else (Ascii (false, true, false, false, false, false, true, true))::[]
+| Nil -> (Ascii (false, false, false, false, false, false, true, true))::[]
+| PFixnum a ->
+  let Ascii (b1, b2, b3, b4, b5, b6, b7, b) = a in
+  (Ascii (b1, b2, b3, b4, b5, b6, b7, false))::[]
+| NFixnum a ->
+  let Ascii (b1, b2, b3, b4, b5, b, b0, b6) = a in
+  (Ascii (b1, b2, b3, b4, b5, true, true, true))::[]
+| Uint8 c ->
+  (Ascii (false, false, true, true, false, false, true,
+    true))::(list_of_ascii8 c)
+| Uint16 c ->
+  (Ascii (true, false, true, true, false, false, true,
+    true))::(list_of_ascii16 c)
+| Uint32 c ->
+  (Ascii (false, true, true, true, false, false, true,
+    true))::(list_of_ascii32 c)
+| Uint64 c ->
+  (Ascii (true, true, true, true, false, false, true,
+    true))::(list_of_ascii64 c)
+| Int8 c ->
+  (Ascii (false, false, false, false, true, false, true,
+    true))::(list_of_ascii8 c)
+| Int16 c ->
+  (Ascii (true, false, false, false, true, false, true,
+    true))::(list_of_ascii16 c)
+| Int32 c ->
+  (Ascii (false, true, false, false, true, false, true,
+    true))::(list_of_ascii32 c)
+| Int64 c ->
+  (Ascii (true, true, false, false, true, false, true,
+    true))::(list_of_ascii64 c)
+| Float c ->
+  (Ascii (false, true, false, true, false, false, true,
+    true))::(list_of_ascii32 c)
+| Double c ->
+  (Ascii (true, true, false, true, false, false, true,
+    true))::(list_of_ascii64 c)
+| FixRaw xs ->
+  let Ascii (b1, b2, b3, b4, b5, b, b0, b6) = atat ascii8_of_nat (length xs)
+  in
+  (Ascii (b1, b2, b3, b4, b5, true, false, true))::xs
+| Raw16 xs ->
+  let (s1, s2) = atat ascii16_of_nat (length xs) in
+  (Ascii (false, true, false, true, true, false, true, true))::(s1::(s2::xs))
+| Raw32 xs ->
+  let (p, p0) = atat ascii32_of_nat (length xs) in
+  let (s1, s2) = p in
+  let (s3, s4) = p0 in
+  (Ascii (true, true, false, true, true, false, true,
+  true))::(s1::(s2::(s3::(s4::xs))))
+| FixArray xs ->
+  let ys = flat_map serialize xs in
+  let Ascii (b1, b2, b3, b4, b, b0, b5, b6) = atat ascii8_of_nat (length xs)
+  in
+  (Ascii (b1, b2, b3, b4, true, false, false, true))::ys
+| Array16 xs ->
+  let ys = flat_map serialize xs in
+  let (s1, s2) = ascii16_of_nat (length xs) in
+  (Ascii (false, false, true, true, true, false, true, true))::(s1::(s2::ys))
+| Array32 xs ->
+  let ys = flat_map serialize xs in
+  let (p, p0) = atat ascii32_of_nat (length xs) in
+  let (s1, s2) = p in
+  let (s3, s4) = p0 in
+  (Ascii (true, false, true, true, true, false, true,
+  true))::(s1::(s2::(s3::(s4::ys))))
+| FixMap xs ->
+  let ys = flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
+  in
+  let Ascii (b1, b2, b3, b4, b, b0, b5, b6) = atat ascii8_of_nat (length xs)
+  in
+  (Ascii (b1, b2, b3, b4, false, false, false, true))::ys
+| Map16 xs ->
+  let ys = flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
+  in
+  let (s1, s2) = ascii16_of_nat (length xs) in
+  (Ascii (false, true, true, true, true, false, true, true))::(s1::(s2::ys))
+| Map32 xs ->
+  let ys = flat_map (fun p -> app (serialize (fst p)) (serialize (snd p))) xs
+  in
+  let s = atat ascii32_of_nat (length xs) in
+  (Ascii (true, true, true, true, true, false, true,
+  true))::((fst (fst s))::((snd (fst s))::((fst (snd s))::((snd (snd s))::ys))))
 
 (** val compact : object0 list -> ascii8 list **)
 
 let compact xs =
-  flat_map (fun x -> match x with
-                       | FixRaw xs0 -> xs0
-                       | _ -> []) xs
+  flat_map (fun x ->
+    match x with
+    | FixRaw xs0 -> xs0
+    | _ -> []) xs
 
 (** val deserialize : int -> ascii8 list -> object0 list **)
 
@@ -477,2105 +2404,1755 @@ let rec deserialize n0 xs =
   (fun fO fS n -> if n=0 then fO () else fS (n-1))
     (fun _ ->
     match xs with
-      | [] -> []
-      | a::ys ->
-          let Ascii (b1, b2, b3, b4, b5, b6, b7, b) = a in
-          if b1
-          then if b2
-               then if b3
-                    then if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+    | [] -> []
+    | a::ys ->
+      let Ascii (b1, b2, b3, b4, b5, b6, b7, b) = a in
+      if b1
+      then if b2
+           then if b3
+                then if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | s3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | s4::ys0 ->
+                                                          let n1 =
+                                                            nat_of_ascii32
+                                                              ((s1, s2), (s3,
+                                                              s4))
+                                                          in
+                                                          let (zs, ws) =
+                                                            atat
+                                                              (split_at
+                                                                (mult
+                                                                  (Pervasives.succ
+                                                                  (Pervasives.succ
+                                                                  0)) n1))
+                                                              (deserialize 0
+                                                                ys0)
+                                                          in
+                                                          (Map32
+                                                          (pair zs))::ws))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s4::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii32 ((s1, s2),
-                                                  (s3, s4))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize n1 ys)
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::l2 ->
+                                                          (match l2 with
+                                                           | [] -> []
+                                                           | c5::l3 ->
+                                                             (match l3 with
+                                                              | [] -> []
+                                                              | c6::l4 ->
+                                                                (match l4 with
+                                                                 | [] -> []
+                                                                 | c7::l5 ->
+                                                                   (match l5 with
+                                                                    | [] ->
+                                                                    []
+                                                                    | c8::ys0 ->
+                                                                    (Uint64
+                                                                    (((c1,
+                                                                    c2), (c3,
+                                                                    c4)),
+                                                                    ((c5,
+                                                                    c6), (c7,
+                                                                    c8))))::
+                                                                    (deserialize
+                                                                    0 ys0)))))))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys0)
-                                                  in
-                                                  (Map32 (pair zs))::ws))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::l2 ->
-                                                  (match l2 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c5::l3 ->
-                                                  (match l3 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c6::l4 ->
-                                                  (match l4 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c7::l5 ->
-                                                  (match l5 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c8::ys0 -> (Uint64 (((c1,
-                                                  c2), (c3, c4)), ((c5, c6),
-                                                  (c7,
-                                                  c8))))::
-                                                  (deserialize 0 ys0)))))))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize 0 ys)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize n1 ys)
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                else if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | s3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | s4::ys0 ->
+                                                          let n1 =
+                                                            nat_of_ascii32
+                                                              ((s1, s2), (s3,
+                                                              s4))
+                                                          in
+                                                          let (zs, ws) =
+                                                            atat
+                                                              (split_at n1)
+                                                              (deserialize n1
+                                                                ys0)
+                                                          in
+                                                          (Raw32
+                                                          (compact zs))::ws))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::l2 ->
+                                                          (match l2 with
+                                                           | [] -> []
+                                                           | c5::l3 ->
+                                                             (match l3 with
+                                                              | [] -> []
+                                                              | c6::l4 ->
+                                                                (match l4 with
+                                                                 | [] -> []
+                                                                 | c7::l5 ->
+                                                                   (match l5 with
+                                                                    | [] ->
+                                                                    []
+                                                                    | c8::ys0 ->
+                                                                    (Double
+                                                                    (((c1,
+                                                                    c2), (c3,
+                                                                    c4)),
+                                                                    ((c5,
+                                                                    c6), (c7,
+                                                                    c8))))::
+                                                                    (deserialize
+                                                                    0 ys0)))))))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                    else if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s4::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii32 ((s1, s2),
-                                                  (s3, s4))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys0)
-                                                  in
-                                                  (Raw32 (compact zs))::ws))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::l2 ->
+                                                          (match l2 with
+                                                           | [] -> []
+                                                           | c5::l3 ->
+                                                             (match l3 with
+                                                              | [] -> []
+                                                              | c6::l4 ->
+                                                                (match l4 with
+                                                                 | [] -> []
+                                                                 | c7::l5 ->
+                                                                   (match l5 with
+                                                                    | [] ->
+                                                                    []
+                                                                    | c8::ys0 ->
+                                                                    (Int64
+                                                                    (((c1,
+                                                                    c2), (c3,
+                                                                    c4)),
+                                                                    ((c5,
+                                                                    c6), (c7,
+                                                                    c8))))::
+                                                                    (deserialize
+                                                                    0 ys0)))))))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::l2 ->
-                                                  (match l2 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c5::l3 ->
-                                                  (match l3 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c6::l4 ->
-                                                  (match l4 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c7::l5 ->
-                                                  (match l5 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c8::ys0 -> (Double (((c1,
-                                                  c2), (c3, c4)), ((c5, c6),
-                                                  (c7,
-                                                  c8))))::
-                                                  (deserialize 0 ys0)))))))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (Bool true)::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+           else if b3
+                then if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::l2 ->
-                                                  (match l2 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c5::l3 ->
-                                                  (match l3 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c6::l4 ->
-                                                  (match l4 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c7::l5 ->
-                                                  (match l5 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c8::ys0 -> (Int64 (((c1,
-                                                  c2), (c3, c4)), ((c5, c6),
-                                                  (c7,
-                                                  c8))))::
-                                                  (deserialize 0 ys0)))))))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | s3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | s4::ys0 ->
+                                                          let n1 =
+                                                            nat_of_ascii32
+                                                              ((s1, s2), (s3,
+                                                              s4))
+                                                          in
+                                                          let (zs, ws) =
+                                                            atat
+                                                              (split_at n1)
+                                                              (deserialize 0
+                                                                ys0)
+                                                          in
+                                                          (Array32 zs)::ws))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (Bool
-                                                  true)::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::ys0 ->
+                                                    (Uint16 (c1,
+                                                      c2))::(deserialize 0
+                                                              ys0)))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-               else if b3
-                    then if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s4::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii32 ((s1, s2),
-                                                  (s3, s4))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys0)
-                                                  in
-                                                  (Array32 zs)::ws))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::ys0 -> (Uint16 (c1,
-                                                  c2))::
-                                                  (deserialize 0 ys0)))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                else if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                    else if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::ys0 ->
+                                                    (Int16 (c1,
+                                                      c2))::(deserialize 0
+                                                              ys0)))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+      else if b2
+           then if b3
+                then if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::ys0 -> (Int16 (c1,
-                                                  c2))::
-                                                  (deserialize 0 ys0)))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::ys0 ->
+                                                    let n1 =
+                                                      nat_of_ascii16 (s1, s2)
+                                                    in
+                                                    let (zs, ws) =
+                                                      atat
+                                                        (split_at
+                                                          (mult
+                                                            (Pervasives.succ
+                                                            (Pervasives.succ
+                                                            0)) n1))
+                                                        (deserialize 0 ys0)
+                                                    in
+                                                    (Map16 (pair zs))::ws))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::ys0 ->
+                                                          (Uint32 ((c1, c2),
+                                                            (c3,
+                                                            c4)))::(deserialize
+                                                                    0 ys0)))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-          else if b2
-               then if b3
-                    then if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii16 (s1, s2)
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize n1 ys)
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys0)
-                                                  in
-                                                  (Map16 (pair zs))::ws))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                else if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::ys0 -> (Uint32 ((c1,
-                                                  c2), (c3,
-                                                  c4)))::
-                                                  (deserialize 0 ys0)))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::ys0 ->
+                                                    let n1 =
+                                                      nat_of_ascii16 (s1, s2)
+                                                    in
+                                                    let (zs, ws) =
+                                                      atat (split_at n1)
+                                                        (deserialize n1 ys0)
+                                                    in
+                                                    (Raw16 (compact zs))::ws))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize 0 ys)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
+                                                  (deserialize n1 ys)
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::ys0 ->
+                                                          (Float ((c1, c2),
+                                                            (c3,
+                                                            c4)))::(deserialize
+                                                                    0 ys0)))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
+                                                  false, false))
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | c2::l0 ->
+                                                    (match l0 with
+                                                     | [] -> []
+                                                     | c3::l1 ->
+                                                       (match l1 with
+                                                        | [] -> []
+                                                        | c4::ys0 ->
+                                                          (Int32 ((c1, c2),
+                                                            (c3,
+                                                            c4)))::(deserialize
+                                                                    0 ys0)))))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (Bool
+                                                false)::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                    else if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+           else if b3
+                then if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii16 (s1, s2)
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys0)
-                                                  in
-                                                  (Raw16 (compact zs))::ws))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | s1::l ->
+                                                 (match l with
+                                                  | [] -> []
+                                                  | s2::ys0 ->
+                                                    let n1 =
+                                                      nat_of_ascii16 (s1, s2)
+                                                    in
+                                                    let (zs, ws) =
+                                                      atat (split_at n1)
+                                                        (deserialize 0 ys0)
+                                                    in
+                                                    (Array16 zs)::ws))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::ys0 -> (Float ((c1,
-                                                  c2), (c3,
-                                                  c4)))::
-                                                  (deserialize 0 ys0)))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::ys0 ->
+                                                 (Uint8
+                                                   c1)::(deserialize 0 ys0))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c2::l0 ->
-                                                  (match l0 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c3::l1 ->
-                                                  (match l1 with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c4::ys0 -> (Int32 ((c1,
-                                                  c2), (c3,
-                                                  c4)))::
-                                                  (deserialize 0 ys0)))))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (Bool
-                                                  false)::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-               else if b3
-                    then if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                else if b4
+                     then if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s1::l ->
-                                                  (match l with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  s2::ys0 ->
-                                                  let n1 =
-                                                  nat_of_ascii16 (s1, s2)
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys0)
-                                                  in
-                                                  (Array16 zs)::ws))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::ys0 -> (Uint8
-                                                  c1)::
-                                                  (deserialize 0 ys0))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then []
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                     else if b5
+                          then if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then (match ys with
+                                               | [] -> []
+                                               | c1::ys0 ->
+                                                 (Int8
+                                                   c1)::(deserialize 0 ys0))
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
+                                              in
+                                              (FixArray zs)::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                          else if b6
+                               then if b7
+                                    then if b
+                                         then (NFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, true, true,
+                                                true)))::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, b5, false, false,
+                                                  false))
+                                              in
+                                              let (zs, ws) =
+                                                atat (split_at n1)
                                                   (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
+                                              in
+                                              (FixRaw (compact zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                               else if b7
+                                    then if b
+                                         then Nil::(deserialize 0 ys)
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys)
+                                    else if b
+                                         then let n1 =
+                                                nat_of_ascii8 (Ascii (b1, b2,
+                                                  b3, b4, false, false,
                                                   false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
+                                              in
+                                              let (zs, ws) =
+                                                atat
                                                   (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                    else if b4
-                         then if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then []
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
-                                                  (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                         else if b5
-                              then if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then (match ys with
-                                                    | 
-                                                  [] -> []
-                                                    | 
-                                                  c1::ys0 -> (Int8
-                                                  c1)::
-                                                  (deserialize 0 ys0))
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixArray zs)::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                              else if b6
-                                   then if b7
-                                        then if b
-                                             then (NFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, true, true,
-                                                  true)))::
-                                                  (deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, b5, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat 
-                                                  (split_at n1)
-                                                  (deserialize n1 ys)
-                                                  in
-                                                  (FixRaw (compact zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                   else if b7
-                                        then if b
-                                             then Nil::(deserialize 0 ys)
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys)
-                                        else if b
-                                             then let n1 =
-                                                  nat_of_ascii8 (Ascii (b1,
-                                                  b2, b3, b4, false, false,
-                                                  false, false))
-                                                  in
-                                                  let (
-                                                  zs, ws) =
-                                                  atat
-                                                  (split_at
-                                                  (mult (succ (succ 0)) n1))
-                                                  (deserialize 0 ys)
-                                                  in
-                                                  (FixMap (pair zs))::ws
-                                             else (PFixnum (Ascii (b1, b2,
-                                                  b3, b4, b5, b6, b7,
-                                                  false)))::
-                                                  (deserialize 0 ys))
+                                                    (mult (Pervasives.succ
+                                                      (Pervasives.succ 0))
+                                                      n1)) (deserialize 0 ys)
+                                              in
+                                              (FixMap (pair zs))::ws
+                                         else (PFixnum (Ascii (b1, b2, b3,
+                                                b4, b5, b6, b7,
+                                                false)))::(deserialize 0 ys))
     (fun m ->
     match xs with
-      | [] -> []
-      | y::ys -> (FixRaw (y::[]))::(deserialize m ys))
+    | [] -> []
+    | y::ys -> (FixRaw (y::[]))::(deserialize m ys))
     n0
 

--- a/lib/core/msgpackCore.mli
+++ b/lib/core/msgpackCore.mli
@@ -1,3 +1,7 @@
+type __ = Obj.t
+
+val negb : bool -> bool
+
 val fst : ('a1 * 'a2) -> 'a1
 
 val snd : ('a1 * 'a2) -> 'a2
@@ -6,51 +10,576 @@ val length : 'a1 list -> int
 
 val app : 'a1 list -> 'a1 list -> 'a1 list
 
+type comparison =
+| Eq
+| Lt
+| Gt
+
+type compareSpecT =
+| CompEqT
+| CompLtT
+| CompGtT
+
+val compareSpec2Type : comparison -> compareSpecT
+
+type 'a compSpecT = compareSpecT
+
+val compSpec2Type : 'a1 -> 'a1 -> comparison -> 'a1 compSpecT
+
+type 'a sig0 =
+  'a
+  (* singleton inductive, whose constructor was exist *)
+
 val plus : int -> int -> int
 
 val mult : int -> int -> int
 
+val nat_iter : int -> ('a1 -> 'a1) -> 'a1 -> 'a1
+
 type positive =
-  | XI of positive
-  | XO of positive
-  | XH
-
-val psucc : positive -> positive
-
-val pplus : positive -> positive -> positive
-
-val pplus_carry : positive -> positive -> positive
-
-val pmult_nat : positive -> int -> int
-
-val nat_of_P : positive -> int
-
-val p_of_succ_nat : int -> positive
-
-val pmult : positive -> positive -> positive
+| XI of positive
+| XO of positive
+| XH
 
 type n =
-  | N0
-  | Npos of positive
+| N0
+| Npos of positive
 
-val nplus : n -> n -> n
+type reflect =
+| ReflectT
+| ReflectF
 
-val nmult : n -> n -> n
+val iff_reflect : bool -> reflect
 
-val nat_of_N : n -> int
+module Pos : 
+ sig 
+  type t = positive
+  
+  val succ : positive -> positive
+  
+  val add : positive -> positive -> positive
+  
+  val add_carry : positive -> positive -> positive
+  
+  val pred_double : positive -> positive
+  
+  val pred : positive -> positive
+  
+  val pred_N : positive -> n
+  
+  type mask =
+  | IsNul
+  | IsPos of positive
+  | IsNeg
+  
+  val mask_rect : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1
+  
+  val mask_rec : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1
+  
+  val succ_double_mask : mask -> mask
+  
+  val double_mask : mask -> mask
+  
+  val double_pred_mask : positive -> mask
+  
+  val pred_mask : mask -> mask
+  
+  val sub_mask : positive -> positive -> mask
+  
+  val sub_mask_carry : positive -> positive -> mask
+  
+  val sub : positive -> positive -> positive
+  
+  val mul : positive -> positive -> positive
+  
+  val iter : positive -> ('a1 -> 'a1) -> 'a1 -> 'a1
+  
+  val pow : positive -> positive -> positive
+  
+  val square : positive -> positive
+  
+  val div2 : positive -> positive
+  
+  val div2_up : positive -> positive
+  
+  val size_nat : positive -> int
+  
+  val size : positive -> positive
+  
+  val compare_cont : positive -> positive -> comparison -> comparison
+  
+  val compare : positive -> positive -> comparison
+  
+  val min : positive -> positive -> positive
+  
+  val max : positive -> positive -> positive
+  
+  val eqb : positive -> positive -> bool
+  
+  val leb : positive -> positive -> bool
+  
+  val ltb : positive -> positive -> bool
+  
+  val sqrtrem_step :
+    (positive -> positive) -> (positive -> positive) -> (positive * mask) ->
+    positive * mask
+  
+  val sqrtrem : positive -> positive * mask
+  
+  val sqrt : positive -> positive
+  
+  val gcdn : int -> positive -> positive -> positive
+  
+  val gcd : positive -> positive -> positive
+  
+  val ggcdn : int -> positive -> positive -> positive * (positive * positive)
+  
+  val ggcd : positive -> positive -> positive * (positive * positive)
+  
+  val coq_Nsucc_double : n -> n
+  
+  val coq_Ndouble : n -> n
+  
+  val coq_lor : positive -> positive -> positive
+  
+  val coq_land : positive -> positive -> n
+  
+  val ldiff : positive -> positive -> n
+  
+  val coq_lxor : positive -> positive -> n
+  
+  val shiftl_nat : positive -> int -> positive
+  
+  val shiftr_nat : positive -> int -> positive
+  
+  val shiftl : positive -> n -> positive
+  
+  val shiftr : positive -> n -> positive
+  
+  val testbit_nat : positive -> int -> bool
+  
+  val testbit : positive -> n -> bool
+  
+  val iter_op : ('a1 -> 'a1 -> 'a1) -> positive -> 'a1 -> 'a1
+  
+  val to_nat : positive -> int
+  
+  val of_nat : int -> positive
+  
+  val of_succ_nat : int -> positive
+ end
 
-val n_of_nat : int -> n
+module Coq_Pos : 
+ sig 
+  type t = positive
+  
+  val succ : positive -> positive
+  
+  val add : positive -> positive -> positive
+  
+  val add_carry : positive -> positive -> positive
+  
+  val pred_double : positive -> positive
+  
+  val pred : positive -> positive
+  
+  val pred_N : positive -> n
+  
+  type mask = Pos.mask =
+  | IsNul
+  | IsPos of positive
+  | IsNeg
+  
+  val mask_rect : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1
+  
+  val mask_rec : 'a1 -> (positive -> 'a1) -> 'a1 -> mask -> 'a1
+  
+  val succ_double_mask : mask -> mask
+  
+  val double_mask : mask -> mask
+  
+  val double_pred_mask : positive -> mask
+  
+  val pred_mask : mask -> mask
+  
+  val sub_mask : positive -> positive -> mask
+  
+  val sub_mask_carry : positive -> positive -> mask
+  
+  val sub : positive -> positive -> positive
+  
+  val mul : positive -> positive -> positive
+  
+  val iter : positive -> ('a1 -> 'a1) -> 'a1 -> 'a1
+  
+  val pow : positive -> positive -> positive
+  
+  val square : positive -> positive
+  
+  val div2 : positive -> positive
+  
+  val div2_up : positive -> positive
+  
+  val size_nat : positive -> int
+  
+  val size : positive -> positive
+  
+  val compare_cont : positive -> positive -> comparison -> comparison
+  
+  val compare : positive -> positive -> comparison
+  
+  val min : positive -> positive -> positive
+  
+  val max : positive -> positive -> positive
+  
+  val eqb : positive -> positive -> bool
+  
+  val leb : positive -> positive -> bool
+  
+  val ltb : positive -> positive -> bool
+  
+  val sqrtrem_step :
+    (positive -> positive) -> (positive -> positive) -> (positive * mask) ->
+    positive * mask
+  
+  val sqrtrem : positive -> positive * mask
+  
+  val sqrt : positive -> positive
+  
+  val gcdn : int -> positive -> positive -> positive
+  
+  val gcd : positive -> positive -> positive
+  
+  val ggcdn : int -> positive -> positive -> positive * (positive * positive)
+  
+  val ggcd : positive -> positive -> positive * (positive * positive)
+  
+  val coq_Nsucc_double : n -> n
+  
+  val coq_Ndouble : n -> n
+  
+  val coq_lor : positive -> positive -> positive
+  
+  val coq_land : positive -> positive -> n
+  
+  val ldiff : positive -> positive -> n
+  
+  val coq_lxor : positive -> positive -> n
+  
+  val shiftl_nat : positive -> int -> positive
+  
+  val shiftr_nat : positive -> int -> positive
+  
+  val shiftl : positive -> n -> positive
+  
+  val shiftr : positive -> n -> positive
+  
+  val testbit_nat : positive -> int -> bool
+  
+  val testbit : positive -> n -> bool
+  
+  val iter_op : ('a1 -> 'a1 -> 'a1) -> positive -> 'a1 -> 'a1
+  
+  val to_nat : positive -> int
+  
+  val of_nat : int -> positive
+  
+  val of_succ_nat : int -> positive
+  
+  val eq_dec : positive -> positive -> bool
+  
+  val peano_rect : 'a1 -> (positive -> 'a1 -> 'a1) -> positive -> 'a1
+  
+  val peano_rec : 'a1 -> (positive -> 'a1 -> 'a1) -> positive -> 'a1
+  
+  type coq_PeanoView =
+  | PeanoOne
+  | PeanoSucc of positive * coq_PeanoView
+  
+  val coq_PeanoView_rect :
+    'a1 -> (positive -> coq_PeanoView -> 'a1 -> 'a1) -> positive ->
+    coq_PeanoView -> 'a1
+  
+  val coq_PeanoView_rec :
+    'a1 -> (positive -> coq_PeanoView -> 'a1 -> 'a1) -> positive ->
+    coq_PeanoView -> 'a1
+  
+  val peanoView_xO : positive -> coq_PeanoView -> coq_PeanoView
+  
+  val peanoView_xI : positive -> coq_PeanoView -> coq_PeanoView
+  
+  val peanoView : positive -> coq_PeanoView
+  
+  val coq_PeanoView_iter :
+    'a1 -> (positive -> 'a1 -> 'a1) -> positive -> coq_PeanoView -> 'a1
+  
+  val eqb_spec : positive -> positive -> reflect
+  
+  val switch_Eq : comparison -> comparison -> comparison
+  
+  val mask2cmp : mask -> comparison
+  
+  val leb_spec0 : positive -> positive -> reflect
+  
+  val ltb_spec0 : positive -> positive -> reflect
+  
+  module Private_Tac : 
+   sig 
+    
+   end
+  
+  module Private_Dec : 
+   sig 
+    val max_case_strong :
+      positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+      (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+    
+    val max_case :
+      positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+      'a1 -> 'a1 -> 'a1
+    
+    val max_dec : positive -> positive -> bool
+    
+    val min_case_strong :
+      positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+      (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+    
+    val min_case :
+      positive -> positive -> (positive -> positive -> __ -> 'a1 -> 'a1) ->
+      'a1 -> 'a1 -> 'a1
+    
+    val min_dec : positive -> positive -> bool
+   end
+  
+  val max_case_strong :
+    positive -> positive -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+  
+  val max_case : positive -> positive -> 'a1 -> 'a1 -> 'a1
+  
+  val max_dec : positive -> positive -> bool
+  
+  val min_case_strong :
+    positive -> positive -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+  
+  val min_case : positive -> positive -> 'a1 -> 'a1 -> 'a1
+  
+  val min_dec : positive -> positive -> bool
+ end
+
+module N : 
+ sig 
+  type t = n
+  
+  val zero : n
+  
+  val one : n
+  
+  val two : n
+  
+  val succ_double : n -> n
+  
+  val double : n -> n
+  
+  val succ : n -> n
+  
+  val pred : n -> n
+  
+  val succ_pos : n -> positive
+  
+  val add : n -> n -> n
+  
+  val sub : n -> n -> n
+  
+  val mul : n -> n -> n
+  
+  val compare : n -> n -> comparison
+  
+  val eqb : n -> n -> bool
+  
+  val leb : n -> n -> bool
+  
+  val ltb : n -> n -> bool
+  
+  val min : n -> n -> n
+  
+  val max : n -> n -> n
+  
+  val div2 : n -> n
+  
+  val even : n -> bool
+  
+  val odd : n -> bool
+  
+  val pow : n -> n -> n
+  
+  val square : n -> n
+  
+  val log2 : n -> n
+  
+  val size : n -> n
+  
+  val size_nat : n -> int
+  
+  val pos_div_eucl : positive -> n -> n * n
+  
+  val div_eucl : n -> n -> n * n
+  
+  val div : n -> n -> n
+  
+  val modulo : n -> n -> n
+  
+  val gcd : n -> n -> n
+  
+  val ggcd : n -> n -> n * (n * n)
+  
+  val sqrtrem : n -> n * n
+  
+  val sqrt : n -> n
+  
+  val coq_lor : n -> n -> n
+  
+  val coq_land : n -> n -> n
+  
+  val ldiff : n -> n -> n
+  
+  val coq_lxor : n -> n -> n
+  
+  val shiftl_nat : n -> int -> n
+  
+  val shiftr_nat : n -> int -> n
+  
+  val shiftl : n -> n -> n
+  
+  val shiftr : n -> n -> n
+  
+  val testbit_nat : n -> int -> bool
+  
+  val testbit : n -> n -> bool
+  
+  val to_nat : n -> int
+  
+  val of_nat : int -> n
+  
+  val iter : n -> ('a1 -> 'a1) -> 'a1 -> 'a1
+  
+  val eq_dec : n -> n -> bool
+  
+  val discr : n -> positive option
+  
+  val binary_rect : 'a1 -> (n -> 'a1 -> 'a1) -> (n -> 'a1 -> 'a1) -> n -> 'a1
+  
+  val binary_rec : 'a1 -> (n -> 'a1 -> 'a1) -> (n -> 'a1 -> 'a1) -> n -> 'a1
+  
+  val peano_rect : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1
+  
+  val peano_rec : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1
+  
+  val leb_spec0 : n -> n -> reflect
+  
+  val ltb_spec0 : n -> n -> reflect
+  
+  module Private_BootStrap : 
+   sig 
+    
+   end
+  
+  val recursion : 'a1 -> (n -> 'a1 -> 'a1) -> n -> 'a1
+  
+  module Private_OrderTac : 
+   sig 
+    module IsTotal : 
+     sig 
+      
+     end
+    
+    module Tac : 
+     sig 
+      
+     end
+   end
+  
+  module Private_NZPow : 
+   sig 
+    
+   end
+  
+  module Private_NZSqrt : 
+   sig 
+    
+   end
+  
+  val sqrt_up : n -> n
+  
+  val log2_up : n -> n
+  
+  module Private_NZDiv : 
+   sig 
+    
+   end
+  
+  val lcm : n -> n -> n
+  
+  val eqb_spec : n -> n -> reflect
+  
+  val b2n : bool -> n
+  
+  val setbit : n -> n -> n
+  
+  val clearbit : n -> n -> n
+  
+  val ones : n -> n
+  
+  val lnot : n -> n -> n
+  
+  module Private_Tac : 
+   sig 
+    
+   end
+  
+  module Private_Dec : 
+   sig 
+    val max_case_strong :
+      n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> (__ -> 'a1) -> (__ -> 'a1) ->
+      'a1
+    
+    val max_case :
+      n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> 'a1 -> 'a1 -> 'a1
+    
+    val max_dec : n -> n -> bool
+    
+    val min_case_strong :
+      n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> (__ -> 'a1) -> (__ -> 'a1) ->
+      'a1
+    
+    val min_case :
+      n -> n -> (n -> n -> __ -> 'a1 -> 'a1) -> 'a1 -> 'a1 -> 'a1
+    
+    val min_dec : n -> n -> bool
+   end
+  
+  val max_case_strong : n -> n -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+  
+  val max_case : n -> n -> 'a1 -> 'a1 -> 'a1
+  
+  val max_dec : n -> n -> bool
+  
+  val min_case_strong : n -> n -> (__ -> 'a1) -> (__ -> 'a1) -> 'a1
+  
+  val min_case : n -> n -> 'a1 -> 'a1 -> 'a1
+  
+  val min_dec : n -> n -> bool
+ end
 
 val flat_map : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list
 
 val eucl_dev : int -> int -> (int * int)
 
 type ascii =
-  | Ascii of bool * bool * bool * bool * bool * bool * bool * bool
+| Ascii of bool * bool * bool * bool * bool * bool * bool * bool
 
-val zero : ascii
+val zero0 : ascii
 
-val one : ascii
+val one0 : ascii
 
 val shift : bool -> ascii -> ascii
 
@@ -74,7 +603,7 @@ val split_at : int -> 'a1 list -> 'a1 list * 'a1 list
 
 val pair : 'a1 list -> ('a1 * 'a1) list
 
-val pow : int -> int
+val pow0 : int -> int
 
 val divmod : int -> int -> (int * int)
 
@@ -107,29 +636,29 @@ val list_of_ascii32 : ascii32 -> ascii8 list
 val list_of_ascii64 : ascii64 -> ascii8 list
 
 type object0 =
-  | Bool of bool
-  | Nil
-  | PFixnum of ascii8
-  | NFixnum of ascii8
-  | Uint8 of ascii8
-  | Uint16 of ascii16
-  | Uint32 of ascii32
-  | Uint64 of ascii64
-  | Int8 of ascii8
-  | Int16 of ascii16
-  | Int32 of ascii32
-  | Int64 of ascii64
-  | Float of ascii32
-  | Double of ascii64
-  | FixRaw of ascii8 list
-  | Raw16 of ascii8 list
-  | Raw32 of ascii8 list
-  | FixArray of object0 list
-  | Array16 of object0 list
-  | Array32 of object0 list
-  | FixMap of (object0 * object0) list
-  | Map16 of (object0 * object0) list
-  | Map32 of (object0 * object0) list
+| Bool of bool
+| Nil
+| PFixnum of ascii8
+| NFixnum of ascii8
+| Uint8 of ascii8
+| Uint16 of ascii16
+| Uint32 of ascii32
+| Uint64 of ascii64
+| Int8 of ascii8
+| Int16 of ascii16
+| Int32 of ascii32
+| Int64 of ascii64
+| Float of ascii32
+| Double of ascii64
+| FixRaw of ascii8 list
+| Raw16 of ascii8 list
+| Raw32 of ascii8 list
+| FixArray of object0 list
+| Array16 of object0 list
+| Array32 of object0 list
+| FixMap of (object0 * object0) list
+| Map16 of (object0 * object0) list
+| Map32 of (object0 * object0) list
 
 val atat : ('a1 -> 'a2) -> 'a1 -> 'a2
 

--- a/lib/core/pack.ml
+++ b/lib/core/pack.ml
@@ -28,6 +28,9 @@ type t =
   | `Map16 of (t * t) list
   | `Map32 of (t * t) list ]
 
+let map f l =
+  List.rev (List.rev_map f l)
+
 let ascii8 n =
   Ascii(n land 0b0000_0001 <> 0,
 	n land 0b0000_0010 <> 0,
@@ -129,23 +132,23 @@ let rec pack = function
   | `Double n ->
       Double (ascii64_of_int64 @@ Int64.bits_of_float n)
   | `FixRaw cs ->
-      FixRaw (List.map ascii8_of_char cs)
+      FixRaw (map ascii8_of_char cs)
   | `Raw16 cs ->
-      Raw16 (List.map ascii8_of_char cs)
+      Raw16 (map ascii8_of_char cs)
   | `Raw32 cs ->
-      Raw32 (List.map ascii8_of_char cs)
+      Raw32 (map ascii8_of_char cs)
   | `FixArray xs ->
-      FixArray (List.map pack xs)
+      FixArray (map pack xs)
   | `Array16 xs ->
-      Array16 (List.map pack xs)
+      Array16 (map pack xs)
   | `Array32 xs ->
-      Array32 (List.map pack xs)
+      Array32 (map pack xs)
   | `FixMap xs ->
-      FixMap (List.map (fun (x,y) -> (pack x, pack y)) xs)
+      FixMap (map (fun (x,y) -> (pack x, pack y)) xs)
   | `Map16 xs ->
-      Map16 (List.map (fun (x,y) -> (pack x, pack y)) xs)
+      Map16 (map (fun (x,y) -> (pack x, pack y)) xs)
   | `Map32 xs ->
-      Map32 (List.map (fun (x,y) -> (pack x, pack y)) xs)
+      Map32 (map (fun (x,y) -> (pack x, pack y)) xs)
 
 let of_ascii8 (Ascii(b1,b2,b3,b4,b5,b6,b7,b8)) =
   List.fold_left (fun x y -> 2 * x + (if y then 1 else 0)) 0 [ b8; b7; b6; b5; b4; b3; b2; b1 ]
@@ -195,12 +198,12 @@ let rec unpack  = function
   | Int64  c -> `Int64 (int64_of_ascii64 c)
   | Float  c -> `Float (Int32.float_of_bits (int32_of_ascii32 c))
   | Double c -> `Double (Int64.float_of_bits (int64_of_ascii64 c))
-  | FixRaw cs -> `FixRaw (List.map char_of_ascii8 cs)
-  | Raw16  cs -> `Raw16 (List.map char_of_ascii8 cs)
-  | Raw32  cs -> `Raw32 (List.map char_of_ascii8 cs)
-  | FixArray xs -> `FixArray (List.map unpack xs)
-  | Array16 xs -> `Array16 (List.map unpack xs)
-  | Array32 xs -> `Array32 (List.map unpack xs)
-  | FixMap  xs -> `FixMap (List.map (fun (x,y) -> (unpack x, unpack y)) xs)
-  | Map16  xs -> `Map16 (List.map (fun (x,y) -> (unpack x, unpack y)) xs)
-  | Map32  xs -> `Map32 (List.map (fun (x,y) -> (unpack x, unpack y)) xs)
+  | FixRaw cs -> `FixRaw (map char_of_ascii8 cs)
+  | Raw16  cs -> `Raw16 (map char_of_ascii8 cs)
+  | Raw32  cs -> `Raw32 (map char_of_ascii8 cs)
+  | FixArray xs -> `FixArray (map unpack xs)
+  | Array16 xs -> `Array16 (map unpack xs)
+  | Array32 xs -> `Array32 (map unpack xs)
+  | FixMap  xs -> `FixMap (map (fun (x,y) -> (unpack x, unpack y)) xs)
+  | Map16  xs -> `Map16 (map (fun (x,y) -> (unpack x, unpack y)) xs)
+  | Map32  xs -> `Map32 (map (fun (x,y) -> (unpack x, unpack y)) xs)

--- a/lib/core/serialize.ml
+++ b/lib/core/serialize.ml
@@ -24,5 +24,6 @@ let serialize_string obj =
   obj
   +> Pack.pack
   +> MsgpackCore.serialize
-  +> List.map Pack.char_of_ascii8
+  +> List.rev_map Pack.char_of_ascii8
+  +> List.rev
   +> implode

--- a/proof/ExtractUtil.v
+++ b/proof/ExtractUtil.v
@@ -31,6 +31,11 @@ Extract Constant mlint_of_mlchar => "int_of_char".
 
 (* list *)
 Extract Inductive list => "list" ["[]" "(::)"].
+(* tail-recursive list functions *)
+Extract Constant List.length => "List.length".
+Extract Constant List.app => "(fun l m -> List.rev (List.rev_append m (List.rev l)))".
+Extract Constant List.flat_map =>
+  "(fun f xs -> List.rev (List.fold_left (fun acc x -> List.rev_append (f x) acc) [] xs))".
 
 (* option *)
 Extract Inductive option => "option" ["None" "Some"].

--- a/test/core/packTest.ml
+++ b/test/core/packTest.ml
@@ -178,4 +178,14 @@ let tests = [
         end
       end
     end;
+  "long_string" >:: begin fun _ ->
+    let rec make_list acc = function
+      | 0 -> acc
+      | n -> make_list ('A' :: acc) (n-1)
+    in
+    (* This will stack-overflow on x86-64 Linux with 8MB stack *)
+    let orig = `Raw32 (make_list [] 10_000_000) in
+    let packed = pack orig in
+    assert_equal orig (unpack packed)
+  end;
 ]


### PR DESCRIPTION
We've been using this library for a few years at issuu, and we've run into several stack-overflow crashes on large inputs because of calls into non-tail-recursive list functions in either the Coq or OCaml standard library. We are currently maintaining our own fork with fixes to these issues, and we would like to merge those fixes upstream.
I recommend viewing the commits individually. The first commit has no semantic changes but simply updates the auto-generated code to Coq 8.4pl6, which is the version I have installed. This makes sure the subsequent changes to the Coq code produce a clean diff.
I added `Extract Constant` declarations to the Coq code to replace Coq standard library functions with custom tail-recursive ones. It would of course be better to implement the tail-recursive versions in Coq and prove them equivalent to the standard library versions, but I hope you'll agree that adding a bit more unverified code is better than keeping the code that is verified but crashes on large inputs.