### PR TITLE
Tail-recursive serialize without redundant reversals

### DIFF
--- a/lib/core/msgpackCore.ml
+++ b/lib/core/msgpackCore.ml
@@ -2149,10 +2149,10 @@ let length_tailrec xs =
 let rev_tailrec xs =
   rev' xs
 
-(** val flat_map_tailrec : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list **)
+(** val map_tailrec : ('a1 -> 'a2) -> 'a1 list -> 'a2 list **)
 
-let flat_map_tailrec f xs =
-  rev_tailrec (fold_left (fun acc x -> rev_append (f x) acc) xs [])
+let map_tailrec f xs =
+  rev_tailrec (fold_left (fun acc x -> (f x)::acc) xs [])
 
 (** val take : int -> 'a1 list -> 'a1 list **)
 
@@ -2434,10 +2434,17 @@ let rec serialize_rev obj acc =
 (** val compact : object0 list -> ascii8 list **)
 
 let compact xs =
-  flat_map_tailrec (fun x ->
+  map_tailrec (fun x ->
     match x with
-    | FixRaw xs0 -> xs0
-    | _ -> []) xs
+    | FixRaw l ->
+      (match l with
+       | [] -> Ascii (false, false, false, false, true, true, false, false)
+       | x0::l0 ->
+         (match l0 with
+          | [] -> x0
+          | a::l1 ->
+            Ascii (false, false, false, false, true, true, false, false)))
+    | _ -> Ascii (false, false, false, false, true, true, false, false)) xs
 
 (** val deserialize : int -> ascii8 list -> object0 list **)
 

--- a/lib/core/msgpackCore.ml
+++ b/lib/core/msgpackCore.ml
@@ -2321,11 +2321,6 @@ type object0 =
 | Map16 of (object0 * object0) list
 | Map32 of (object0 * object0) list
 
-(** val atat : ('a1 -> 'a2) -> 'a1 -> 'a2 **)
-
-let atat f x =
-  f x
-
 (** val serialize : object0 -> ascii8 list **)
 
 let rec serialize = function
@@ -2372,14 +2367,14 @@ let rec serialize = function
     true))::(list_of_ascii64 c)
 | FixRaw xs ->
   let Ascii (b1, b2, b3, b4, b5, b, b0, b6) =
-    atat ascii8_of_nat (length_tailrec xs)
+    ascii8_of_nat (length_tailrec xs)
   in
   (Ascii (b1, b2, b3, b4, b5, true, false, true))::xs
 | Raw16 xs ->
-  let (s1, s2) = atat ascii16_of_nat (length_tailrec xs) in
+  let (s1, s2) = ascii16_of_nat (length_tailrec xs) in
   (Ascii (false, true, false, true, true, false, true, true))::(s1::(s2::xs))
 | Raw32 xs ->
-  let (p, p0) = atat ascii32_of_nat (length_tailrec xs) in
+  let (p, p0) = ascii32_of_nat (length_tailrec xs) in
   let (s1, s2) = p in
   let (s3, s4) = p0 in
   (Ascii (true, true, false, true, true, false, true,
@@ -2387,7 +2382,7 @@ let rec serialize = function
 | FixArray xs ->
   let ys = flat_map_tailrec serialize xs in
   let Ascii (b1, b2, b3, b4, b, b0, b5, b6) =
-    atat ascii8_of_nat (length_tailrec xs)
+    ascii8_of_nat (length_tailrec xs)
   in
   (Ascii (b1, b2, b3, b4, true, false, false, true))::ys
 | Array16 xs ->
@@ -2396,7 +2391,7 @@ let rec serialize = function
   (Ascii (false, false, true, true, true, false, true, true))::(s1::(s2::ys))
 | Array32 xs ->
   let ys = flat_map_tailrec serialize xs in
-  let (p, p0) = atat ascii32_of_nat (length_tailrec xs) in
+  let (p, p0) = ascii32_of_nat (length_tailrec xs) in
   let (s1, s2) = p in
   let (s3, s4) = p0 in
   (Ascii (true, false, true, true, true, false, true,
@@ -2407,7 +2402,7 @@ let rec serialize = function
       app_tailrec (serialize (fst p)) (serialize (snd p))) xs
   in
   let Ascii (b1, b2, b3, b4, b, b0, b5, b6) =
-    atat ascii8_of_nat (length_tailrec xs)
+    ascii8_of_nat (length_tailrec xs)
   in
   (Ascii (b1, b2, b3, b4, false, false, false, true))::ys
 | Map16 xs ->
@@ -2422,7 +2417,7 @@ let rec serialize = function
     flat_map_tailrec (fun p ->
       app_tailrec (serialize (fst p)) (serialize (snd p))) xs
   in
-  let s = atat ascii32_of_nat (length_tailrec xs) in
+  let s = ascii32_of_nat (length_tailrec xs) in
   (Ascii (true, true, true, true, true, false, true,
   true))::((fst (fst s))::((snd (fst s))::((fst (snd s))::((snd (snd s))::ys))))
 
@@ -2464,7 +2459,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2491,12 +2486,11 @@ let rec deserialize n0 xs =
                                                               s4))
                                                           in
                                                           let (zs, ws) =
-                                                            atat
-                                                              (split_at
-                                                                (mult
-                                                                  (Pervasives.succ
-                                                                  (Pervasives.succ
-                                                                  0)) n1))
+                                                            split_at
+                                                              (mult
+                                                                (Pervasives.succ
+                                                                (Pervasives.succ
+                                                                0)) n1)
                                                               (deserialize 0
                                                                 ys0)
                                                           in
@@ -2512,7 +2506,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -2535,7 +2529,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2588,11 +2582,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -2615,7 +2608,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2635,7 +2628,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -2658,7 +2651,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2678,11 +2671,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -2706,7 +2698,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2733,8 +2725,7 @@ let rec deserialize n0 xs =
                                                               s4))
                                                           in
                                                           let (zs, ws) =
-                                                            atat
-                                                              (split_at n1)
+                                                            split_at n1
                                                               (deserialize n1
                                                                 ys0)
                                                           in
@@ -2750,7 +2741,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -2773,7 +2764,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2826,11 +2817,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -2853,7 +2843,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2906,7 +2896,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -2929,7 +2919,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -2949,11 +2939,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -2978,7 +2967,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3005,8 +2994,7 @@ let rec deserialize n0 xs =
                                                               s4))
                                                           in
                                                           let (zs, ws) =
-                                                            atat
-                                                              (split_at n1)
+                                                            split_at n1
                                                               (deserialize 0
                                                                 ys0)
                                                           in
@@ -3021,7 +3009,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3044,7 +3032,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3072,11 +3060,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3099,7 +3086,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3119,7 +3106,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3142,7 +3129,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3162,11 +3149,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3190,7 +3176,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3210,7 +3196,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3233,7 +3219,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3253,11 +3239,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3280,7 +3265,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3308,7 +3293,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3331,7 +3316,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3351,11 +3336,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3381,7 +3365,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3400,12 +3384,11 @@ let rec deserialize n0 xs =
                                                       nat_of_ascii16 (s1, s2)
                                                     in
                                                     let (zs, ws) =
-                                                      atat
-                                                        (split_at
-                                                          (mult
-                                                            (Pervasives.succ
-                                                            (Pervasives.succ
-                                                            0)) n1))
+                                                      split_at
+                                                        (mult
+                                                          (Pervasives.succ
+                                                          (Pervasives.succ
+                                                          0)) n1)
                                                         (deserialize 0 ys0)
                                                     in
                                                     (Map16 (pair zs))::ws))
@@ -3419,7 +3402,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3442,7 +3425,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3477,11 +3460,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3504,7 +3486,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3524,7 +3506,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3547,7 +3529,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3567,11 +3549,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3595,7 +3576,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3614,7 +3595,7 @@ let rec deserialize n0 xs =
                                                       nat_of_ascii16 (s1, s2)
                                                     in
                                                     let (zs, ws) =
-                                                      atat (split_at n1)
+                                                      split_at n1
                                                         (deserialize n1 ys0)
                                                     in
                                                     (Raw16 (compact zs))::ws))
@@ -3628,7 +3609,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3651,7 +3632,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3686,11 +3667,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3713,7 +3693,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3748,7 +3728,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3771,7 +3751,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3792,11 +3772,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3821,7 +3800,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3840,7 +3819,7 @@ let rec deserialize n0 xs =
                                                       nat_of_ascii16 (s1, s2)
                                                     in
                                                     let (zs, ws) =
-                                                      atat (split_at n1)
+                                                      split_at n1
                                                         (deserialize 0 ys0)
                                                     in
                                                     (Array16 zs)::ws))
@@ -3854,7 +3833,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3877,7 +3856,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3901,11 +3880,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -3928,7 +3906,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3948,7 +3926,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -3971,7 +3949,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -3991,11 +3969,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -4019,7 +3996,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -4039,7 +4016,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -4062,7 +4039,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -4082,11 +4059,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,
@@ -4109,7 +4085,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -4133,7 +4109,7 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize 0 ys)
                                               in
                                               (FixArray zs)::ws
@@ -4156,7 +4132,7 @@ let rec deserialize n0 xs =
                                                   false))
                                               in
                                               let (zs, ws) =
-                                                atat (split_at n1)
+                                                split_at n1
                                                   (deserialize n1 ys)
                                               in
                                               (FixRaw (compact zs))::ws
@@ -4176,11 +4152,10 @@ let rec deserialize n0 xs =
                                                   false, false))
                                               in
                                               let (zs, ws) =
-                                                atat
-                                                  (split_at
-                                                    (mult (Pervasives.succ
-                                                      (Pervasives.succ 0))
-                                                      n1)) (deserialize 0 ys)
+                                                split_at
+                                                  (mult (Pervasives.succ
+                                                    (Pervasives.succ 0)) n1)
+                                                  (deserialize 0 ys)
                                               in
                                               (FixMap (pair zs))::ws
                                          else (PFixnum (Ascii (b1, b2, b3,

--- a/lib/core/msgpackCore.mli
+++ b/lib/core/msgpackCore.mli
@@ -6,8 +6,6 @@ val fst : ('a1 * 'a2) -> 'a1
 
 val snd : ('a1 * 'a2) -> 'a2
 
-val length : 'a1 list -> int
-
 val app : 'a1 list -> 'a1 list -> 'a1 list
 
 type comparison =
@@ -570,7 +568,11 @@ module N :
   val min_dec : n -> n -> bool
  end
 
-val flat_map : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list
+val rev_append : 'a1 list -> 'a1 list -> 'a1 list
+
+val rev' : 'a1 list -> 'a1 list
+
+val fold_left : ('a1 -> 'a2 -> 'a1) -> 'a2 list -> 'a1 -> 'a1
 
 val eucl_dev : int -> int -> (int * int)
 
@@ -594,6 +596,14 @@ val n_of_digits : bool list -> n
 val n_of_ascii : ascii -> n
 
 val nat_of_ascii : ascii -> int
+
+val length_tailrec : 'a1 list -> int
+
+val rev_tailrec : 'a1 list -> 'a1 list
+
+val app_tailrec : 'a1 list -> 'a1 list -> 'a1 list
+
+val flat_map_tailrec : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list
 
 val take : int -> 'a1 list -> 'a1 list
 

--- a/lib/core/msgpackCore.mli
+++ b/lib/core/msgpackCore.mli
@@ -601,8 +601,6 @@ val length_tailrec : 'a1 list -> int
 
 val rev_tailrec : 'a1 list -> 'a1 list
 
-val app_tailrec : 'a1 list -> 'a1 list -> 'a1 list
-
 val flat_map_tailrec : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list
 
 val take : int -> 'a1 list -> 'a1 list
@@ -670,7 +668,15 @@ type object0 =
 | Map16 of (object0 * object0) list
 | Map32 of (object0 * object0) list
 
-val serialize : object0 -> ascii8 list
+val serialize_rev_list :
+  (object0 -> ascii8 list -> ascii8 list) -> object0 list -> ascii8 list ->
+  ascii8 list
+
+val serialize_rev_kvs :
+  (object0 -> ascii8 list -> ascii8 list) -> (object0 * object0) list ->
+  ascii8 list -> ascii8 list
+
+val serialize_rev : object0 -> ascii list -> ascii8 list
 
 val compact : object0 list -> ascii8 list
 

--- a/lib/core/msgpackCore.mli
+++ b/lib/core/msgpackCore.mli
@@ -601,7 +601,7 @@ val length_tailrec : 'a1 list -> int
 
 val rev_tailrec : 'a1 list -> 'a1 list
 
-val flat_map_tailrec : ('a1 -> 'a2 list) -> 'a1 list -> 'a2 list
+val map_tailrec : ('a1 -> 'a2) -> 'a1 list -> 'a2 list
 
 val take : int -> 'a1 list -> 'a1 list
 

--- a/lib/core/msgpackCore.mli
+++ b/lib/core/msgpackCore.mli
@@ -670,8 +670,6 @@ type object0 =
 | Map16 of (object0 * object0) list
 | Map32 of (object0 * object0) list
 
-val atat : ('a1 -> 'a2) -> 'a1 -> 'a2
-
 val serialize : object0 -> ascii8 list
 
 val compact : object0 list -> ascii8 list

--- a/lib/core/serialize.ml
+++ b/lib/core/serialize.ml
@@ -23,7 +23,6 @@ let deserialize_string str =
 let serialize_string obj =
   obj
   +> Pack.pack
-  +> MsgpackCore.serialize
+  +> (fun objs -> MsgpackCore.serialize_rev objs [])
   +> List.rev_map Pack.char_of_ascii8
-  +> List.rev
   +> implode

--- a/proof/DeserializeImplement.v
+++ b/proof/DeserializeImplement.v
@@ -355,7 +355,7 @@ destruct b1,b2,b3,b4,b5;
     (let n := nat_of_ascii8 (ascii8_of_nat (length cs)) in
      let (zs, ws) := split_at n @@ deserialize n (cs++bs) in
      FixRaw (compact zs) :: ws));
-  [ unfold atat, split_at;
+  [ unfold split_at;
     rewrite nat_ascii8_embedding, deserialize_take_length, deserialize_drop_length, compact_eq, <- H13
   | rewrite <- H7])...
 Qed.
@@ -376,7 +376,7 @@ change (deserialize 0 _ ) with
   (let (zs, ws) :=
     split_at (nat_of_ascii16 (s1,s2)) @@ deserialize (nat_of_ascii16 (s1,s2)) (cs++bs) in
     Raw16 (compact zs) :: ws).
-unfold atat, split_at.
+unfold split_at.
 rewrite H7, nat_ascii16_embedding, deserialize_take_length, deserialize_drop_length, compact_eq, H10...
 Qed.
 
@@ -396,7 +396,7 @@ change (deserialize 0 _ ) with
   (let (zs, ws) :=
     split_at (nat_of_ascii32 ((s1,s2),(s3,s4))) @@ deserialize (nat_of_ascii32 ((s1,s2),(s3,s4))) (cs++bs) in
     Raw32 (compact zs) :: ws).
-unfold atat, split_at.
+unfold split_at.
 rewrite H7, nat_ascii32_embedding, deserialize_take_length, deserialize_drop_length, compact_eq, H12...
 Qed.
 
@@ -424,7 +424,7 @@ destruct b1, b2, b3, b4;
       split_at (nat_of_ascii8 (ascii8_of_nat n0)) @@ deserialize 0 bs
     in
       FixArray zs :: ws);
-   [ unfold atat; rewrite H9, nat_ascii8_embedding, <- H12 | rewrite <- H14])...
+   [ rewrite H9, nat_ascii8_embedding, <- H12 | rewrite <- H14])...
 Qed.
 
 Lemma correct_array16 : forall os bs n xs ys s1 s2 ,
@@ -512,7 +512,7 @@ destruct b1, b2, b3, b4;
        split_at (2 * (nat_of_ascii8 (ascii8_of_nat n))) @@ deserialize 0 bs
      in
        FixMap (pair zs) :: ws);
-    [ unfold atat; rewrite nat_ascii8_embedding, H11, <- H13
+    [ rewrite nat_ascii8_embedding, H11, <- H13
     | rewrite <- H16 ])...
 Qed.
 
@@ -544,7 +544,6 @@ apply H in H10.
 change (deserialize 0 ("222" :: s1 :: s2 :: bs)) with
   (let (zs, ws) := split_at (2 * nat_of_ascii16 (s1, s2)) @@ deserialize 0 bs in
   Map16 (pair zs) :: ws).
-unfold atat.
 rewrite H10, H14, nat_ascii16_embedding, <- H11...
 Qed.
 
@@ -573,7 +572,6 @@ apply H in H11.
 change (deserialize 0 ("223" :: s1 :: s2 :: s3 :: s4 :: bs)) with
   (let (zs, ws) := split_at (2 * nat_of_ascii32 ((s1, s2),(s3,s4))) @@ deserialize 0 bs in
     Map32 (pair zs) :: ws).
-unfold atat.
 rewrite H16, H11, nat_ascii32_embedding, <- H13...
 Qed.
 

--- a/proof/DeserializeImplement.v
+++ b/proof/DeserializeImplement.v
@@ -4,10 +4,10 @@ Require Import ListUtil Object MultiByte Util SerializeSpec Pow SerializedList P
 Open Scope char_scope.
 
 Definition compact (xs : list object) : list ascii8 :=
-  flat_map_tailrec (fun x => match x with
-                               | FixRaw xs =>  xs
-                               | _ => []
-                             end)
+  map_tailrec (fun x => match x with
+                          | FixRaw [x] =>  x
+                          | _ => "0"
+                        end)
   xs.
 
 Fixpoint deserialize (n : nat) (xs : list ascii8) {struct xs} :=
@@ -329,7 +329,7 @@ Lemma compact_eq : forall xs,
 Proof with auto.
 intros.
 unfold compact.
-rewrite flat_map_tailrec_equiv.
+rewrite map_tailrec_equiv.
 induction xs; [ reflexivity | intros ].
 simpl.
 rewrite IHxs...

--- a/proof/DeserializeImplement.v
+++ b/proof/DeserializeImplement.v
@@ -4,10 +4,10 @@ Require Import ListUtil Object MultiByte Util SerializeSpec Pow SerializedList P
 Open Scope char_scope.
 
 Definition compact (xs : list object) : list ascii8 :=
-  List.flat_map (fun x => match x with
-                            FixRaw xs =>  xs
-                            | _ => []
-                          end)
+  flat_map_tailrec (fun x => match x with
+                               | FixRaw xs =>  xs
+                               | _ => []
+                             end)
   xs.
 
 Fixpoint deserialize (n : nat) (xs : list ascii8) {struct xs} :=
@@ -327,6 +327,9 @@ Qed.
 Lemma compact_eq : forall xs,
   compact (List.map (fun x => FixRaw [ x ]) xs) = xs.
 Proof with auto.
+intros.
+unfold compact.
+rewrite flat_map_tailrec_equiv.
 induction xs; [ reflexivity | intros ].
 simpl.
 rewrite IHxs...

--- a/proof/ExtractUtil.v
+++ b/proof/ExtractUtil.v
@@ -31,11 +31,6 @@ Extract Constant mlint_of_mlchar => "int_of_char".
 
 (* list *)
 Extract Inductive list => "list" ["[]" "(::)"].
-(* tail-recursive list functions *)
-Extract Constant List.length => "List.length".
-Extract Constant List.app => "(fun l m -> List.rev (List.rev_append m (List.rev l)))".
-Extract Constant List.flat_map =>
-  "(fun f xs -> List.rev (List.fold_left (fun acc x -> List.rev_append (f x) acc) [] xs))".
 
 (* option *)
 Extract Inductive option => "option" ["None" "Some"].

--- a/proof/ListUtil.v
+++ b/proof/ListUtil.v
@@ -22,36 +22,31 @@ Proof.
   reflexivity.
 Qed.
 
-Definition flat_map_tailrec {A B} (f: A -> list B) (xs: list A) :=
-  rev_tailrec (fold_left (fun acc x => rev_append (f x) acc) xs []).
+Definition map_tailrec {A B} (f: A -> B) (xs: list A) :=
+  rev_tailrec (fold_left (fun acc x => f x :: acc) xs []).
 
-Lemma flat_map_tailrec_equiv: forall A B (f: A -> list B) (xs: list A),
-  flat_map_tailrec f xs = flat_map f xs.
+Lemma map_tailrec_equiv: forall A B (f: A -> B) (xs: list A),
+  map_tailrec f xs = map f xs.
 Proof.
   intros.
-  unfold flat_map_tailrec.
+  unfold map_tailrec.
   rewrite rev_tailrec_equiv.
-  set (body := fun acc x => rev_append (f x) acc).
+  set (body := fun acc x => f x :: acc).
   assert (Hlemma: forall xs ys zs, fold_left body xs (ys ++ zs) = fold_left body xs ys ++ zs).
   { clear.
     intros xs.
-    induction xs; simpl.
-    - reflexivity.
-    - intros.
-      rewrite <-IHxs.
-      f_equal.
-      unfold body; simpl.
-      rewrite !rev_append_rev, app_assoc.
-      reflexivity.
-  }
-  induction xs; simpl.
-  - reflexivity.
-  - rewrite <-IHxs.
-    rewrite <-(rev_involutive (f a)).
-    rewrite (rev_alt (f a)).
-    rewrite <-rev_app_distr.
-    rewrite <-Hlemma.
+    induction xs; [reflexivity|].
+    intros.
+    simpl.
+    rewrite <-IHxs.
     reflexivity.
+  }
+  induction xs; [reflexivity|].
+  simpl.
+  rewrite <-IHxs.
+  rewrite <-rev_unit.
+  rewrite <-Hlemma.
+  reflexivity.
 Qed.
 
 Lemma rev_append_app_left: forall A (xs ys zs: list A),

--- a/proof/ListUtil.v
+++ b/proof/ListUtil.v
@@ -22,19 +22,6 @@ Proof.
   reflexivity.
 Qed.
 
-Definition app_tailrec {A} (xs ys: list A) :=
-  rev_tailrec (rev_append ys (rev_tailrec xs)).
-
-Lemma app_tailrec_equiv: forall A (xs ys: list A),
-  app_tailrec xs ys = app xs ys.
-Proof.
-  intros.
-  unfold app_tailrec.
-  rewrite !rev_tailrec_equiv, rev_append_rev.
-  rewrite <-distr_rev, rev_involutive.
-  reflexivity.
-Qed.
-
 Definition flat_map_tailrec {A B} (f: A -> list B) (xs: list A) :=
   rev_tailrec (fold_left (fun acc x => rev_append (f x) acc) xs []).
 
@@ -65,6 +52,16 @@ Proof.
     rewrite <-rev_app_distr.
     rewrite <-Hlemma.
     reflexivity.
+Qed.
+
+Lemma rev_append_app_left: forall A (xs ys zs: list A),
+  rev_append (ys ++ xs) zs = rev_append xs (rev_append ys zs).
+Proof.
+  intros.
+  rewrite !rev_append_rev.
+  rewrite rev_app_distr.
+  rewrite app_assoc.
+  reflexivity.
 Qed.
 
 Lemma app_same : forall A (xs ys zs : list A),
@@ -320,4 +317,26 @@ replace (2 * (length ((x1,x2) :: xs))) with (length (unpair ((x1,x2)::xs))).
  simpl.
  rewrite unpair_length.
  omega.
+Qed.
+
+(* Class of functions that prepend something to their argument. These
+ * will typically be tail-recursive functions that maintain an
+ * accumulator. *)
+Definition Prepending {A} (f: list A -> list A) := forall ys zs,
+  f (ys ++ zs) = f ys ++ zs.
+
+Lemma Prepending_nil: forall {A} f, Prepending f -> forall (zs: list A),
+  f zs = f [] ++ zs.
+Proof.
+  unfold Prepending. intros * H *. apply (H [] zs).
+Qed.
+
+Lemma Prepending_rev_append: forall A (xs: list A),
+  Prepending (rev_append xs).
+Proof.
+unfold Prepending.
+intros.
+rewrite !rev_append_rev.
+rewrite app_assoc.
+reflexivity.
 Qed.

--- a/proof/Main.v
+++ b/proof/Main.v
@@ -1,3 +1,3 @@
 Require Import ExtrOcamlBasic ExtrOcamlIntConv ExtrOcamlNatInt.
 Require Import SerializeImplement DeserializeImplement.
-Extraction "msgpackCore.ml" serialize deserialize.
+Extraction "msgpackCore.ml" serialize_rev deserialize.

--- a/proof/SerializeImplement.v
+++ b/proof/SerializeImplement.v
@@ -23,66 +23,66 @@ Fixpoint serialize (obj : object) : list ascii8 :=
     | Float  c => "202"::list_of_ascii32 c
     | Double c => "203"::list_of_ascii64 c
     | FixRaw xs =>
-      match ascii8_of_nat @@ length xs with
+      match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 b5 _ _ _ =>
           (Ascii b1 b2 b3 b4 b5 true false true)::xs
       end
     | Raw16 xs =>
       let (s1,s2) :=
-        ascii16_of_nat @@ length xs
+        ascii16_of_nat @@ length_tailrec xs
       in
         "218"::s1::s2::xs
     | Raw32 xs =>
-      match ascii32_of_nat @@ length xs with
+      match ascii32_of_nat @@ length_tailrec xs with
         | ((s1,s2),(s3,s4)) =>
           "219"::s1::s2::s3::s4::xs
       end
     | FixArray xs =>
       let ys :=
-        flat_map serialize xs
+        flat_map_tailrec serialize xs
       in
-      match ascii8_of_nat @@ length xs with
+      match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 _ _ _ _ =>
           (Ascii b1 b2 b3 b4 true false false true)::ys
       end
     | Array16 xs =>
       let ys :=
-        flat_map serialize xs
+        flat_map_tailrec serialize xs
       in
       let (s1, s2) :=
-        ascii16_of_nat (length  xs)
+        ascii16_of_nat (length_tailrec xs)
       in
         "220"::s1::s2::ys
     | Array32 xs =>
       let ys :=
-        flat_map serialize xs
+        flat_map_tailrec serialize xs
       in
-      match ascii32_of_nat @@ length xs with
+      match ascii32_of_nat @@ length_tailrec xs with
         | ((s1,s2),(s3,s4)) =>
          "221"::s1::s2::s3::s4::ys
       end
     | FixMap xs =>
       let ys :=
-        flat_map (fun p => serialize (fst p) ++ serialize (snd p)) xs
+        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
       in
-      match ascii8_of_nat @@ length xs with
+      match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 _ _ _ _ =>
           (Ascii b1 b2 b3 b4 false false false true)::ys
       end
     | Map16 xs =>
       let ys :=
-        flat_map (fun p => serialize (fst p) ++ serialize (snd p)) xs
+        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
       in
       let (s1, s2) :=
-        ascii16_of_nat (length  xs)
+        ascii16_of_nat (length_tailrec xs)
       in
         "222"::s1::s2::ys
     | Map32 xs =>
       let ys :=
-        flat_map (fun p => serialize (fst p) ++ serialize (snd p)) xs
+        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
       in
       let s :=
-        ascii32_of_nat @@ length xs
+        ascii32_of_nat @@ length_tailrec xs
       in
         "223"::(fst (fst s))::(snd (fst s))::(fst (snd s))::(snd (snd s))::ys
   end.
@@ -197,6 +197,7 @@ unfold Correct.
 intros.
 inversion H0.
 simpl.
+rewrite length_tailrec_equiv.
 unfold atat.
 rewrite_for (ascii8_of_nat (length cs)).
 reflexivity.
@@ -210,6 +211,7 @@ unfold Correct.
 intros.
 inversion H0.
 simpl.
+rewrite length_tailrec_equiv.
 unfold atat.
 rewrite_for (ascii16_of_nat (length cs)).
 reflexivity.
@@ -223,6 +225,7 @@ unfold Correct.
 intros.
 inversion H0.
 simpl.
+rewrite length_tailrec_equiv.
 unfold atat.
 rewrite_for (ascii32_of_nat (length cs)).
 reflexivity.
@@ -294,12 +297,15 @@ Proof.
 unfold Correct.
 intros.
 simpl in *.
+rewrite length_tailrec_equiv in *.
+simpl.
 unfold atat in *.
 rewrite_for (ascii8_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
 rewrite_for (ascii8_of_nat (length xs)).
 rewrite_for y.
+rewrite flat_map_tailrec_equiv in *.
 inversion H3.
 reflexivity.
 Qed.
@@ -317,11 +323,14 @@ Proof.
 unfold Correct.
 intros.
 simpl in *.
+rewrite length_tailrec_equiv in *.
+simpl.
 rewrite_for (ascii16_of_nat (S (length xs))).
 apply H2 in H1; auto.
 apply H4 in H3; auto.
 rewrite_for (ascii16_of_nat (length xs)).
 rewrite_for y.
+rewrite flat_map_tailrec_equiv in *.
 inversion H3.
 reflexivity.
 Qed.
@@ -338,12 +347,15 @@ Proof.
   unfold Correct.
   intros.
   simpl in *.
+  rewrite length_tailrec_equiv in *.
+  simpl.
   unfold atat in *.
   rewrite_for (ascii32_of_nat (S (length xs))).
   apply H2 in H1; auto.
   apply H4 in H3; auto.
   rewrite_for y.
   rewrite <- H in H3.
+  rewrite flat_map_tailrec_equiv in *.
   inversion H3.
   auto.
 Qed.
@@ -360,6 +372,8 @@ Proof.
 unfold Correct.
 intros.
 simpl in *.
+rewrite length_tailrec_equiv in *.
+simpl.
 unfold atat in *.
 rewrite_for (ascii8_of_nat (S (length xs))).
 apply H2 in H1.
@@ -368,6 +382,9 @@ apply H6 in H5.
 rewrite_for (ascii8_of_nat (length xs)).
 rewrite_for y1.
 rewrite_for y2.
+rewrite flat_map_tailrec_equiv in *.
+simpl.
+rewrite app_tailrec_equiv in *.
 inversion H5.
 rewrite <- app_assoc.
 reflexivity.
@@ -387,6 +404,8 @@ Proof.
 unfold Correct.
 intros.
 simpl in *.
+rewrite length_tailrec_equiv in *.
+simpl.
 rewrite_for (ascii16_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
@@ -394,6 +413,9 @@ apply H6 in H5.
 rewrite_for (ascii16_of_nat (length xs)).
 rewrite_for y1.
 rewrite_for y2.
+rewrite flat_map_tailrec_equiv in *.
+simpl.
+rewrite app_tailrec_equiv in *.
 inversion H5.
 rewrite <- app_assoc.
 reflexivity.
@@ -414,19 +436,26 @@ intros.
 unfold Correct.
 intros.
 simpl in *.
+rewrite length_tailrec_equiv in *.
+simpl.
 unfold atat in *.
 rewrite_for (ascii32_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
 apply H6 in H5.
+rewrite flat_map_tailrec_equiv.
 simpl.
+rewrite app_tailrec_equiv in *.
 rewrite_for y1.
 rewrite_for y2.
 rewrite <- app_assoc.
 simpl in H5.
+rewrite length_tailrec_equiv in H5.
+simpl in H5.
 unfold atat in H5.
 rewrite_for (ascii32_of_nat (length xs)).
 simpl in H5.
+rewrite flat_map_tailrec_equiv in *.
 inversion H5.
 reflexivity.
 Qed.

--- a/proof/SerializeImplement.v
+++ b/proof/SerializeImplement.v
@@ -3,93 +3,86 @@ Require Import ListUtil Object MultiByte Util SerializeSpec ProofUtil.
 
 Open Scope char_scope.
 
-Fixpoint serialize (obj : object) : list ascii8 :=
+Definition serialize_rev_list (serialize_rev: object -> list ascii8 -> list ascii8) :=
+  fix F os acc :=
+    match os with
+    | [] => acc
+    | o :: os => F os (serialize_rev o acc)
+    end.
+
+Definition serialize_rev_kvs (serialize_rev: object -> list ascii8 -> list ascii8) :=
+  fix F ps acc :=
+    match ps with
+    | [] => acc
+    | (k,v) :: ps => F ps (serialize_rev v (serialize_rev k acc))
+    end.
+
+Fixpoint serialize_rev (obj : object) acc : list ascii8 :=
   match obj with
-    | Nil        => [ "192" ]
-    | Bool false => [ "194" ]
-    | Bool true  => [ "195" ]
+    | Nil        => "192" :: acc
+    | Bool false => "194" :: acc
+    | Bool true  => "195" :: acc
     | PFixnum (Ascii b1 b2 b3 b4 b5 b6 b7 _) =>
-      [ Ascii b1 b2 b3 b4 b5 b6 b7 false ]
+      (Ascii b1 b2 b3 b4 b5 b6 b7 false) :: acc
     | NFixnum (Ascii b1 b2 b3 b4 b5 _ _ _) =>
-      [ Ascii b1 b2 b3 b4 b5 true true true ]
-    | Uint8  c => "204"::list_of_ascii8 c
-    | Uint16 c => "205"::list_of_ascii16 c
-    | Uint32 c => "206"::list_of_ascii32 c
-    | Uint64 c => "207"::list_of_ascii64 c
-    | Int8   c => "208"::list_of_ascii8 c
-    | Int16  c => "209"::list_of_ascii16 c
-    | Int32  c => "210"::list_of_ascii32 c
-    | Int64  c => "211"::list_of_ascii64 c
-    | Float  c => "202"::list_of_ascii32 c
-    | Double c => "203"::list_of_ascii64 c
+      (Ascii b1 b2 b3 b4 b5 true true true) :: acc
+    | Uint8  c => rev_append (list_of_ascii8  c) ("204":: acc)
+    | Uint16 c => rev_append (list_of_ascii16 c) ("205" :: acc)
+    | Uint32 c => rev_append (list_of_ascii32 c) ("206" :: acc)
+    | Uint64 c => rev_append (list_of_ascii64 c) ("207" :: acc)
+    | Int8   c => rev_append (list_of_ascii8  c) ("208" :: acc)
+    | Int16  c => rev_append (list_of_ascii16 c) ("209" :: acc)
+    | Int32  c => rev_append (list_of_ascii32 c) ("210" :: acc)
+    | Int64  c => rev_append (list_of_ascii64 c) ("211" :: acc)
+    | Float  c => rev_append (list_of_ascii32 c) ("202" :: acc)
+    | Double c => rev_append (list_of_ascii64 c) ("203" :: acc)
     | FixRaw xs =>
       match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 b5 _ _ _ =>
-          (Ascii b1 b2 b3 b4 b5 true false true)::xs
+          rev_append xs ((Ascii b1 b2 b3 b4 b5 true false true) :: acc)
       end
     | Raw16 xs =>
-      let (s1,s2) :=
-        ascii16_of_nat @@ length_tailrec xs
-      in
-        "218"::s1::s2::xs
+      let (s1,s2) := ascii16_of_nat @@ length_tailrec xs in
+      rev_append xs (s2 :: s1 :: "218" :: acc)
     | Raw32 xs =>
       match ascii32_of_nat @@ length_tailrec xs with
         | ((s1,s2),(s3,s4)) =>
-          "219"::s1::s2::s3::s4::xs
+          rev_append xs (s4 :: s3 :: s2 :: s1 :: "219" :: acc)
       end
     | FixArray xs =>
-      let ys :=
-        flat_map_tailrec serialize xs
-      in
       match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 _ _ _ _ =>
-          (Ascii b1 b2 b3 b4 true false false true)::ys
+          serialize_rev_list serialize_rev xs
+            ((Ascii b1 b2 b3 b4 true false false true) :: acc)
       end
     | Array16 xs =>
-      let ys :=
-        flat_map_tailrec serialize xs
-      in
-      let (s1, s2) :=
-        ascii16_of_nat (length_tailrec xs)
-      in
-        "220"::s1::s2::ys
+      let (s1, s2) := ascii16_of_nat @@ length_tailrec xs in
+      serialize_rev_list serialize_rev xs (s2 :: s1 :: "220" :: acc)
     | Array32 xs =>
-      let ys :=
-        flat_map_tailrec serialize xs
-      in
       match ascii32_of_nat @@ length_tailrec xs with
         | ((s1,s2),(s3,s4)) =>
-         "221"::s1::s2::s3::s4::ys
+          serialize_rev_list serialize_rev xs (s4 :: s3 :: s2 :: s1 :: "221" :: acc)
       end
     | FixMap xs =>
-      let ys :=
-        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
-      in
       match ascii8_of_nat @@ length_tailrec xs with
         | Ascii b1 b2 b3 b4 _ _ _ _ =>
-          (Ascii b1 b2 b3 b4 false false false true)::ys
+          serialize_rev_kvs serialize_rev xs
+            ((Ascii b1 b2 b3 b4 false false false true) :: acc)
       end
     | Map16 xs =>
-      let ys :=
-        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
-      in
-      let (s1, s2) :=
-        ascii16_of_nat (length_tailrec xs)
-      in
-        "222"::s1::s2::ys
+      let (s1, s2) := ascii16_of_nat @@ length_tailrec xs in
+      serialize_rev_kvs serialize_rev xs (s2 :: s1 :: "222" :: acc)
     | Map32 xs =>
-      let ys :=
-        flat_map_tailrec (fun p => app_tailrec (serialize (fst p)) (serialize (snd p))) xs
-      in
-      let s :=
-        ascii32_of_nat @@ length_tailrec xs
-      in
-        "223"::(fst (fst s))::(snd (fst s))::(fst (snd s))::(snd (snd s))::ys
+      match ascii32_of_nat @@ length_tailrec xs with
+        | ((s1,s2),(s3,s4)) =>
+          serialize_rev_kvs serialize_rev xs (s4 :: s3 :: s2 :: s1 :: "223" :: acc)
+      end
   end.
 
 Definition Correct obj xs :=
+  forall acc,
   Serialized obj xs ->
-  serialize obj = xs.
+  serialize_rev obj acc = rev_append xs acc.
 
 Ltac straitfoward :=
   unfold Correct;
@@ -228,13 +221,13 @@ rewrite_for (ascii32_of_nat (length cs)).
 reflexivity.
 Qed.
 
-Lemma correct_fixarray_nil :
+Lemma correct_fixarray_nil:
   Correct (FixArray []) ["144"].
 Proof.
 straitfoward.
 Qed.
 
-Lemma correct_array16_nil :
+Lemma correct_array16_nil:
   Correct (Array16 []) ["220"; "000"; "000"].
 Proof.
 unfold Correct.
@@ -280,6 +273,101 @@ rewrite <- ascii8_of_nat_O.
 reflexivity.
 Qed.
 
+Lemma Prepending_serialize_rev_list': forall f os, (Forall (fun o => Prepending (f o))) os ->
+  Prepending (serialize_rev_list f os).
+Proof.
+  unfold Prepending. intros * H.
+  induction H; [reflexivity|].
+  intros ys zs. simpl. rewrite H. apply IHForall.
+Qed.
+
+Lemma Prepending_serialize_rev_kvs': forall f ps,
+  (Forall (fun p => Prepending (f (fst p)) /\ Prepending (f (snd p)))) ps ->
+  Prepending (serialize_rev_kvs f ps).
+Proof.
+  unfold Prepending. intros * H.
+  induction H as [|[x1 x2] ? [H1 H2]]; [reflexivity|].
+  intros ys zs. simpl. rewrite H1, H2. apply IHForall.
+Qed.
+
+Lemma Prepending_serialize_rev: forall o,
+  Prepending (serialize_rev o).
+Proof.
+unfold Prepending.
+intros.
+generalize ys zs; clear ys zs.
+induction o using object_ind'; intros ys zs; simpl.
+- destruct x; reflexivity.
+- reflexivity.
+- destruct x. reflexivity.
+- destruct x. reflexivity.
+- reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- rewrite <-Prepending_rev_append. reflexivity.
+- destruct (ascii8_of_nat (length_tailrec x)). rewrite <-Prepending_rev_append. reflexivity.
+- destruct (ascii16_of_nat (length_tailrec x)). rewrite <-Prepending_rev_append. reflexivity.
+- destruct (ascii32_of_nat (length_tailrec x)) as [[? ?] [? ?]].
+  rewrite <-Prepending_rev_append. reflexivity.
+- destruct (ascii8_of_nat (length_tailrec os)) as [b1 b2 b3 b4 b5 b6 b7 b8].
+  rewrite app_comm_cons.
+  generalize ((Ascii b1 b2 b3 b4 true false false true :: ys)); intros.
+  apply (Prepending_serialize_rev_list' serialize_rev).
+  apply H.
+- destruct (ascii16_of_nat (length_tailrec os)) as [s1 s2].
+  rewrite !app_comm_cons.
+  generalize ((s2 :: s1 :: "220" :: ys)); intros.
+  apply (Prepending_serialize_rev_list' serialize_rev).
+  apply H.
+- destruct (ascii32_of_nat (length_tailrec os)) as [[s1 s2] [s3 s4]].
+  rewrite !app_comm_cons.
+  generalize ((s4 :: s3 :: s2 :: s1 :: "221" :: ys)); intros.
+  apply (Prepending_serialize_rev_list' serialize_rev).
+  apply H.
+- destruct (ascii8_of_nat (length_tailrec ps)) as [b1 b2 b3 b4 b5 b6 b7 b8].
+  rewrite app_comm_cons.
+  generalize ((Ascii b1 b2 b3 b4 false false false true :: ys)); intros.
+  apply (Prepending_serialize_rev_kvs' serialize_rev).
+  apply H.
+- destruct (ascii16_of_nat (length_tailrec ps)) as [s1 s2].
+  rewrite !app_comm_cons.
+  generalize ((s2 :: s1 :: "222" :: ys)); intros.
+  apply (Prepending_serialize_rev_kvs' serialize_rev).
+  apply H.
+- destruct (ascii32_of_nat (length_tailrec ps)) as [[s1 s2] [s3 s4]].
+  rewrite !app_comm_cons.
+  generalize ((s4 :: s3 :: s2 :: s1 :: "223" :: ys)); intros.
+  apply (Prepending_serialize_rev_kvs' serialize_rev).
+  apply H.
+Qed.
+
+Lemma Prepending_serialize_rev_list: forall os,
+  Prepending (serialize_rev_list serialize_rev os).
+Proof.
+  intros.
+  apply Prepending_serialize_rev_list'.
+  apply Forall_forall.
+  intros.
+  apply Prepending_serialize_rev.
+Qed.
+
+Lemma Prepending_serialize_rev_kvs: forall ps,
+  Prepending (serialize_rev_kvs serialize_rev ps).
+Proof.
+  intros.
+  apply Prepending_serialize_rev_kvs'.
+  apply Forall_forall.
+  intros.
+  split; apply Prepending_serialize_rev.
+Qed.
+
+
 Lemma correct_fixarray_cons: forall x xs y ys b1 b2 b3 b4 b5 b6 b7 b8,
   Ascii b1 b2 b3 b4 false false false false = ascii8_of_nat (length xs) ->
   Ascii b5 b6 b7 b8 false false false false = ascii8_of_nat (length (x::xs)) ->
@@ -295,12 +383,17 @@ simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
 rewrite_for (ascii8_of_nat (S (length xs))).
-apply H2 in H1.
-apply H4 in H3.
+eapply H2 in H1.
+apply (H4 acc) in H3.
 rewrite_for (ascii8_of_nat (length xs)).
-rewrite_for y.
-rewrite flat_map_tailrec_equiv in *.
-inversion H3.
+rewrite rev_append_app_left.
+rewrite <-H1.
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)); [|apply Prepending_serialize_rev_list].
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H3.
+rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)) in H3; [|apply Prepending_serialize_rev_list].
+apply app_inv_tail in H3.
+rewrite H3.
 reflexivity.
 Qed.
 
@@ -320,12 +413,17 @@ simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
 rewrite_for (ascii16_of_nat (S (length xs))).
-apply H2 in H1; auto.
-apply H4 in H3; auto.
+eapply H2 in H1; auto.
+specialize (H4 H3 acc).
 rewrite_for (ascii16_of_nat (length xs)).
-rewrite_for y.
-rewrite flat_map_tailrec_equiv in *.
-inversion H3.
+rewrite rev_append_app_left.
+rewrite <-H1.
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)); [|apply Prepending_serialize_rev_list].
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H4.
+rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)) in H4; [|apply Prepending_serialize_rev_list].
+apply app_inv_tail in H4; auto.
+rewrite H4.
 reflexivity.
 Qed.
 
@@ -344,13 +442,18 @@ Proof.
   rewrite length_tailrec_equiv in *.
   simpl.
   rewrite_for (ascii32_of_nat (S (length xs))).
-  apply H2 in H1; auto.
-  apply H4 in H3; auto.
-  rewrite_for y.
-  rewrite <- H in H3.
-  rewrite flat_map_tailrec_equiv in *.
-  inversion H3.
-  auto.
+  eapply H2 in H1; auto.
+  specialize (H4 H3 acc).
+  rewrite_for (ascii32_of_nat (length xs)).
+  rewrite rev_append_app_left.
+  rewrite <-H1.
+  rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+  rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)); [|apply Prepending_serialize_rev_list].
+  rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H4.
+  rewrite (Prepending_nil (serialize_rev_list serialize_rev xs)) in H4; [|apply Prepending_serialize_rev_list].
+  apply app_inv_tail in H4; auto.
+  rewrite H4.
+  reflexivity.
 Qed.
 
 Lemma correct_fixmap_cons: forall x1 x2 xs y1 y2 ys b1 b2 b3 b4 b5 b6 b7 b8,
@@ -368,17 +471,18 @@ simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
 rewrite_for (ascii8_of_nat (S (length xs))).
-apply H2 in H1.
-apply H4 in H3.
-apply H6 in H5.
+eapply H2 in H1.
+eapply H4 in H3.
+apply (H6 acc) in H5.
 rewrite_for (ascii8_of_nat (length xs)).
-rewrite_for y1.
-rewrite_for y2.
-rewrite flat_map_tailrec_equiv in *.
-simpl.
-rewrite app_tailrec_equiv in *.
-inversion H5.
-rewrite <- app_assoc.
+do 2 rewrite rev_append_app_left.
+rewrite <-H1, <-H3.
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)); [|apply Prepending_serialize_rev_kvs].
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H5.
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)) in H5; [|apply Prepending_serialize_rev_kvs].
+apply app_inv_tail in H5.
+rewrite H5.
 reflexivity.
 Qed.
 
@@ -399,17 +503,18 @@ simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
 rewrite_for (ascii16_of_nat (S (length xs))).
-apply H2 in H1.
-apply H4 in H3.
-apply H6 in H5.
+eapply H2 in H1.
+eapply H4 in H3.
+apply (H6 acc) in H5.
 rewrite_for (ascii16_of_nat (length xs)).
-rewrite_for y1.
-rewrite_for y2.
-rewrite flat_map_tailrec_equiv in *.
-simpl.
-rewrite app_tailrec_equiv in *.
-inversion H5.
-rewrite <- app_assoc.
+do 2 rewrite rev_append_app_left.
+rewrite <-H1, <-H3.
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)); [|apply Prepending_serialize_rev_kvs].
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H5.
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)) in H5; [|apply Prepending_serialize_rev_kvs].
+apply app_inv_tail in H5.
+rewrite H5.
 reflexivity.
 Qed.
 
@@ -424,29 +529,24 @@ Lemma correct_map32_cons : forall x1 x2 xs y1 y2 ys s1 s2 s3 s4 t1 t2 t3 t4,
   Correct (Map32 xs) ("223" :: t1 :: t2 :: t3 :: t4 :: ys) ->
   Correct (Map32 ((x1, x2) :: xs)) ("223" :: s1 :: s2 :: s3 :: s4 :: y1 ++ y2 ++ ys).
 Proof.
-intros.
 unfold Correct.
 intros.
 simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
 rewrite_for (ascii32_of_nat (S (length xs))).
-apply H2 in H1.
-apply H4 in H3.
-apply H6 in H5.
-rewrite flat_map_tailrec_equiv.
-simpl.
-rewrite app_tailrec_equiv in *.
-rewrite_for y1.
-rewrite_for y2.
-rewrite <- app_assoc.
-simpl in H5.
-rewrite length_tailrec_equiv in H5.
-simpl in H5.
-rewrite_for (ascii32_of_nat (length xs)).
-simpl in H5.
-rewrite flat_map_tailrec_equiv in *.
-inversion H5.
+eapply H2 in H1.
+eapply H4 in H3.
+apply (H6 acc) in H5.
+rewrite <-H in *.
+do 2 rewrite rev_append_app_left.
+rewrite <-H1, <-H3.
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)).
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)); [|apply Prepending_serialize_rev_kvs].
+rewrite (Prepending_nil _ (Prepending_rev_append _ _)) in H5.
+rewrite (Prepending_nil (serialize_rev_kvs serialize_rev xs)) in H5; [|apply Prepending_serialize_rev_kvs].
+apply app_inv_tail in H5.
+rewrite H5.
 reflexivity.
 Qed.
 
@@ -456,7 +556,7 @@ Lemma correct_intro : forall obj xs,
 Proof.
 unfold Correct.
 intros.
-apply H in H0; auto.
+auto.
 Qed.
 
 Hint Resolve

--- a/proof/SerializeImplement.v
+++ b/proof/SerializeImplement.v
@@ -198,7 +198,6 @@ intros.
 inversion H0.
 simpl.
 rewrite length_tailrec_equiv.
-unfold atat.
 rewrite_for (ascii8_of_nat (length cs)).
 reflexivity.
 Qed.
@@ -212,7 +211,6 @@ intros.
 inversion H0.
 simpl.
 rewrite length_tailrec_equiv.
-unfold atat.
 rewrite_for (ascii16_of_nat (length cs)).
 reflexivity.
 Qed.
@@ -226,7 +224,6 @@ intros.
 inversion H0.
 simpl.
 rewrite length_tailrec_equiv.
-unfold atat.
 rewrite_for (ascii32_of_nat (length cs)).
 reflexivity.
 Qed.
@@ -253,7 +250,6 @@ Proof.
 unfold Correct.
 intros.
 simpl.
-unfold atat.
 rewrite <- ascii8_of_nat_O.
 reflexivity.
 Qed.
@@ -280,7 +276,6 @@ Proof.
 unfold Correct.
 intros.
 simpl.
-unfold atat.
 rewrite <- ascii8_of_nat_O.
 reflexivity.
 Qed.
@@ -299,7 +294,6 @@ intros.
 simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
-unfold atat in *.
 rewrite_for (ascii8_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
@@ -349,7 +343,6 @@ Proof.
   simpl in *.
   rewrite length_tailrec_equiv in *.
   simpl.
-  unfold atat in *.
   rewrite_for (ascii32_of_nat (S (length xs))).
   apply H2 in H1; auto.
   apply H4 in H3; auto.
@@ -374,7 +367,6 @@ intros.
 simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
-unfold atat in *.
 rewrite_for (ascii8_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
@@ -438,7 +430,6 @@ intros.
 simpl in *.
 rewrite length_tailrec_equiv in *.
 simpl.
-unfold atat in *.
 rewrite_for (ascii32_of_nat (S (length xs))).
 apply H2 in H1.
 apply H4 in H3.
@@ -452,7 +443,6 @@ rewrite <- app_assoc.
 simpl in H5.
 rewrite length_tailrec_equiv in H5.
 simpl in H5.
-unfold atat in H5.
 rewrite_for (ascii32_of_nat (length xs)).
 simpl in H5.
 rewrite flat_map_tailrec_equiv in *.

--- a/proof/Util.v
+++ b/proof/Util.v
@@ -32,8 +32,4 @@ Definition get_contents := lmap ascii_of_mlchar get_contents_mlchars.
 
 Definition id {A:Type} (x:A) := x.
 
-Definition atat {A B:Type} (f:A -> B) (x: A) := f x.
-Infix "@@" := atat (right associativity, at level 75).
-
-Definition doll {A B C:Type} (g:B->C) (f:A->B) (x:A) := g (f x).
-Infix "$" := doll (at level 75).
+Notation "f @@ x" := (f x) (right associativity, at level 75, only parsing).


### PR DESCRIPTION
PR #9 fixed stack-overflow crashes by making all list-utility functions tail recursive. The fix has two problems: the new code has no Coq proof, and tail recursion is enabled inefficiently by doing each list operation in reverse and then reversing the result.

This PR instead makes the whole serialize function in Coq produce reversed output, which means that the whole result comes out in reverse and just needs to be reversed once, but there was a redundant reversal after serialize already that could just be removed. The resulting code performs better and is now proved correct in Coq.

I wrote a crude benchmark to get some numbers. My benchmark took 17.1 seconds before this change and 9.2 seconds after. You can reproduce the benchmark numbers by applying [this commit](https://github.com/jj-issuu/msgpack-ocaml/commit/bfa9df5d75a830005bf3ed02e7a5e2d3aef1e43d), running "make test" and inspecting the printed time it took to run the tests.