### PR TITLE
Fix for compilation error while opam install

### DIFF
--- a/lib/conv/msgpack_conv.ml
+++ b/lib/conv/msgpack_conv.ml
@@ -1,4 +1,5 @@
 open MsgpackBase
+open Meta_conv.Types
 
 include Meta_conv.Coder.Make(struct
 
@@ -157,5 +158,5 @@ let option_of_msgpack f =
     | v    -> Some (Some v))
     f
 
-let lazy_t_of_msgpack    f : 'a lazy_t decoder =
-  Helper.lazy_t_of (fun e -> raise (Error e)) f
+let lazy_t_of_msgpack (d : ('a, Msgpack.Serialize.t) Decoder.t) : ('a lazy_t, Msgpack.Serialize.t) Decoder.t =
+  Helper.lazy_t_of (fun (e : Msgpack.Serialize.t Meta_conv.Error.t) -> raise (Exception e)) d


### PR DESCRIPTION
Fix following error:

```sh
$ opam pin add msgpack .                                                      
msgpack is now path-pinned to /msgpack-ocaml                                                                  
                                                                                                              
[msgpack] /msgpack-ocaml/ synchronized                                                                        
[msgpack] Installing new package description from /msgpack-ocaml                                              
                                                                                                              
msgpack needs to be installed.                                                                                
The following actions will be performed:                                                                      
  - install base-num base                               [required by msgpack]                                 
  - install msgpack  1.2.2*                                                                                   
===== 2 to install =====
Do you want to continue ? [Y/n] y                                                                            
                                                                                                              
=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[msgpack.1.2.2] /msgpack-ocaml/ already up-to-date            
                                                             
=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-> installed base-num.base   
[ERROR] The compilation of msgpack failed at "ocaml setup.ml -build".
Processing  2/2: [msgpack: ocamlfind remove]                                                                  
#=== ERROR while installing msgpack.1.2.2 =====================================#                              
# opam-version 1.2.2 (58ef3b8213100953848d362f7120a30356d7f77d)            
# os           linux
# command      ocaml setup.ml -build
# path         /home/opam/.opam/4.04.0/build/msgpack.1.2.2
# compiler     4.04.0
# exit-code    1
# env-file     /home/opam/.opam/4.04.0/build/msgpack.1.2.2/msgpack-18-6d07ae.env
# stdout-file  /home/opam/.opam/4.04.0/build/msgpack.1.2.2/msgpack-18-6d07ae.out
# stderr-file  /home/opam/.opam/4.04.0/build/msgpack.1.2.2/msgpack-18-6d07ae.err
### stdout ###                                                                                                
# [...]
# Warning 32: unused value map.                        
# /home/opam/.opam/4.04.0/bin/ocamlfind ocamlc -c -g -annot -bin-annot -I lib/core -g -w +a -annot -package by
tes -package num -package ppx_meta_conv -I lib/conv -I lib/core -o lib/conv/encode.cmi lib/conv/encode.mli
# /home/opam/.opam/4.04.0/bin/ocamlfind ocamldep -package bytes -package num -package ppx_meta_conv -modules l
ib/conv/encode.ml > lib/conv/encode.ml.depends
# /home/opam/.opam/4.04.0/bin/ocamlfind ocamldep -package bytes -package num -package ppx_meta_conv -modules l
ib/conv/decode.ml > lib/conv/decode.ml.depends
# /home/opam/.opam/4.04.0/bin/ocamlfind ocamlc -c -g -annot -bin-annot -I lib/core -g -w +a -annot -package by
tes -package num -package ppx_meta_conv -I lib/conv -I lib/core -o lib/conv/msgpack_conv.cmo lib/conv/msgpack_
conv.ml
# + /home/opam/.opam/4.04.0/bin/ocamlfind ocamlc -c -g -annot -bin-annot -I lib/core -g -w +a -annot -package
bytes -package num -package ppx_meta_conv -I lib/conv -I lib/core -o lib/conv/msgpack_conv.cmo lib/conv/msgpac
k_conv.ml
# File "lib/conv/msgpack_conv.ml", line 161, characters 36-41:
# Error: This variant expression is expected to have type exn
#        The constructor Error does not belong to type exn
# Command exited with code 2.
### stderr ###
# E: Failure("Command ''/home/opam/.opam/4.04.0/bin/ocamlbuild' lib/core/msgpack.cma lib/core/msgpack.cmxa lib
/core/msgpack.a lib/core/msgpack.cmxs lib/conv/msgpack_conv.cma lib/conv/msgpack_conv.cmxa lib/conv/msgpack_co
nv.a lib/conv/msgpack_conv.cmxs -tag debug' terminated with error code 10")
```