### PR TITLE
Set the minimal OCaml version required

### DIFF
--- a/opam
+++ b/opam
@@ -21,7 +21,7 @@ install: [
 remove: [
   ["ocamlfind" "remove" "msgpack"]
 ]
-
+available: [ ocaml-version >= "4.01.0" ]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
This f.i.x.e.s. the travis build problem in https://github.com/ocaml/opam-repository/pull/9927
You are making use of ```@@```, ```"%revapply"``` (since 4.01) and ```List.iteri``` (since 4.00). If you prefer to stay retro-compatible with older versions please ask, I've got the patch ready.